### PR TITLE
Add line number tracking for Errors

### DIFF
--- a/examples/bad_strs.fl
+++ b/examples/bad_strs.fl
@@ -1,4 +1,5 @@
-x = "
-y = "\w"
-z = "\x3 ninety"
-w = "\x3 ninety \u38"
+x = "abscscsc
+y = "abscscsc
+z = "\w"
+w = "\x3 ninety"
+j = "\x3 ninety \u38"

--- a/src/lexer/error.rs
+++ b/src/lexer/error.rs
@@ -4,14 +4,14 @@ use std::fmt::{Display, Formatter};
 
 #[derive(Debug, PartialEq)]
 pub struct Error {
-    pub(crate) location: Location,
+    pub(crate) loc: Location,
     pub(crate) kind: ErrorKind,
 }
 
 impl Error {
-    pub fn new(location: impl Into<Location>, kind: ErrorKind) -> Self {
+    pub fn new(loc: impl Into<Location>, kind: ErrorKind) -> Self {
         Self {
-            location: location.into(),
+            loc: loc.into(),
             kind,
         }
     }
@@ -32,14 +32,14 @@ impl Display for Error {
             "  {} {}:{}:{}",
             "-->".blue().bold(),
             "temp-file-path",
-            self.location.line,
-            self.location.col
+            self.loc.line,
+            self.loc.col
         )?;
         writeln!(f, "   {}", "|".blue().bold())?;
         writeln!(
             f,
             "{:>2} {} {}",
-            self.location.line.to_string().bold(),
+            self.loc.line.to_string().bold(),
             "|".blue().bold(),
             "pub fn temp_line() {}"
         )?;

--- a/src/lexer/error.rs
+++ b/src/lexer/error.rs
@@ -3,19 +3,50 @@ use std::fmt::{Display, Formatter};
 
 #[derive(Debug, PartialEq)]
 pub struct Error {
+    pub(crate) row: usize,
+    pub(crate) col: usize,
     pub(crate) kind: ErrorKind,
 }
 
 impl Error {
-    pub fn new(kind: ErrorKind) -> Self {
-        Self { kind }
+    pub fn new(location: (usize, usize), kind: ErrorKind) -> Self {
+        Self {
+            row: location.0,
+            col: location.1,
+            kind,
+        }
     }
 }
 impl std::error::Error for Error {}
 
 impl Display for Error {
+    // TODO: What if n digit numbers for rows and cols?
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}: {}", "error".red(), self.kind)
+        writeln!(
+            f,
+            "{}: {}",
+            "error".red().bold(),
+            self.kind.to_string().bold()
+        )?;
+        writeln!(
+            f,
+            "  {} {}:{}:{}",
+            "-->".blue().bold(),
+            "temp-file-path",
+            self.row,
+            self.col
+        )?;
+        writeln!(f, "   {}", "|".blue().bold())?;
+        writeln!(
+            f,
+            "{:>2} {} {}",
+            self.row.to_string().bold(),
+            "|".blue().bold(),
+            "pub fn temp_line()"
+        )?;
+        writeln!(f, "   {}", "|".blue().bold())?;
+        writeln!(f, "   {}", "|".blue().bold())?;
+        Ok(())
     }
 }
 

--- a/src/lexer/error.rs
+++ b/src/lexer/error.rs
@@ -32,14 +32,14 @@ impl Display for Error {
             "  {} {}:{}:{}",
             "-->".blue().bold(),
             "temp-file-path",
-            self.location.row,
+            self.location.line,
             self.location.col
         )?;
         writeln!(f, "   {}", "|".blue().bold())?;
         writeln!(
             f,
             "{:>2} {} {}",
-            self.location.row.to_string().bold(),
+            self.location.line.to_string().bold(),
             "|".blue().bold(),
             "pub fn temp_line() {}"
         )?;

--- a/src/lexer/error.rs
+++ b/src/lexer/error.rs
@@ -1,18 +1,17 @@
+use crate::lexer::location::Location;
 use colored::Colorize;
 use std::fmt::{Display, Formatter};
 
 #[derive(Debug, PartialEq)]
 pub struct Error {
-    pub(crate) row: usize,
-    pub(crate) col: usize,
+    pub(crate) location: Location,
     pub(crate) kind: ErrorKind,
 }
 
 impl Error {
-    pub fn new(location: (usize, usize), kind: ErrorKind) -> Self {
+    pub fn new(location: impl Into<Location>, kind: ErrorKind) -> Self {
         Self {
-            row: location.0,
-            col: location.1,
+            location: location.into(),
             kind,
         }
     }
@@ -33,16 +32,16 @@ impl Display for Error {
             "  {} {}:{}:{}",
             "-->".blue().bold(),
             "temp-file-path",
-            self.row,
-            self.col
+            self.location.row,
+            self.location.col
         )?;
         writeln!(f, "   {}", "|".blue().bold())?;
         writeln!(
             f,
             "{:>2} {} {}",
-            self.row.to_string().bold(),
+            self.location.row.to_string().bold(),
             "|".blue().bold(),
-            "pub fn temp_line()"
+            "pub fn temp_line() {}"
         )?;
         writeln!(f, "   {}", "|".blue().bold())?;
         writeln!(f, "   {}", "|".blue().bold())?;

--- a/src/lexer/location.rs
+++ b/src/lexer/location.rs
@@ -1,0 +1,17 @@
+#[derive(Debug, PartialEq, Copy, Clone)]
+pub struct Location {
+    pub(crate) row: usize,
+    pub(crate) col: usize,
+}
+
+impl Location {
+    pub fn new(row: usize, col: usize) -> Self {
+        Self { row, col }
+    }
+}
+
+impl Into<Location> for (usize, usize) {
+    fn into(self) -> Location {
+        Location::new(self.0, self.1)
+    }
+}

--- a/src/lexer/location.rs
+++ b/src/lexer/location.rs
@@ -1,12 +1,12 @@
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub struct Location {
-    pub(crate) row: usize,
+    pub(crate) line: usize,
     pub(crate) col: usize,
 }
 
 impl Location {
-    pub fn new(row: usize, col: usize) -> Self {
-        Self { row, col }
+    pub fn new(line: usize, col: usize) -> Self {
+        Self { line, col }
     }
 }
 

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -2,6 +2,7 @@ mod error;
 mod source_iterator;
 mod token;
 mod tokens;
+mod location;
 
 pub use token::Bracket;
 pub use token::Comment;

--- a/src/lexer/source_iterator.rs
+++ b/src/lexer/source_iterator.rs
@@ -66,7 +66,7 @@ impl<'a> SourceIterator<'a> {
     /// Returns the next character of the iterator and steps the iterator. This functions also
     /// keeps track of row and column numbers.
     ///
-    /// Assumptions: Every function that steps the iterator does so through this function
+    /// Assumption: Every function that steps the iterator does so through this function
     pub fn next(&mut self) -> Option<char> {
         let next = self.src.next().map(|(_, c)| c);
 

--- a/src/lexer/source_iterator.rs
+++ b/src/lexer/source_iterator.rs
@@ -5,17 +5,17 @@ use std::str::Chars;
 #[derive(Debug)]
 pub struct SourceIterator<'a> {
     /// Location of character that self.next() will return next time it is called
-    next_location: Option<Location>,
+    next_loc: Option<Location>,
     /// Location of what self.next() returned last time it was called
-    cur_location: Option<Location>,
+    cur_loc: Option<Location>,
     src: Peekable<Enumerate<Chars<'a>>>,
 }
 
 impl<'a> SourceIterator<'a> {
     pub fn new(source: &'a str) -> Self {
         Self {
-            next_location: Some(Location::new(1, 1)),
-            cur_location: None,
+            next_loc: Some(Location::new(1, 1)),
+            cur_loc: None,
             src: source.chars().enumerate().peekable(),
         }
     }
@@ -70,24 +70,24 @@ impl<'a> SourceIterator<'a> {
     pub fn next(&mut self) -> Option<char> {
         let next = self.src.next().map(|(_, c)| c);
 
-        self.cur_location = self.next_location;
+        self.cur_loc = self.next_loc;
 
-        // Safe to unwrap self.next_location when next is Some() because next_location is only set to None
+        // Safe to unwrap self.next_loc when next is Some() because next_loc is only set to None
         // when self.src runs out of chars to yield
         match next {
             Some('\n') => {
-                self.next_location.as_mut().unwrap().line += 1;
-                self.next_location.as_mut().unwrap().col = 1;
+                self.next_loc.as_mut().unwrap().line += 1;
+                self.next_loc.as_mut().unwrap().col = 1;
             }
-            Some(_) => self.next_location.as_mut().unwrap().col += 1,
-            None => self.next_location = None,
+            Some(_) => self.next_loc.as_mut().unwrap().col += 1,
+            None => self.next_loc = None,
         }
 
         next
     }
 
     pub fn loc(&self) -> Option<Location> {
-        self.cur_location
+        self.cur_loc
     }
 }
 

--- a/src/lexer/source_iterator.rs
+++ b/src/lexer/source_iterator.rs
@@ -64,7 +64,7 @@ impl<'a> SourceIterator<'a> {
     }
 
     /// Returns the next character of the iterator and steps the iterator. This functions also
-    /// keeps track of row and column numbers.
+    /// keeps track of line and column numbers.
     ///
     /// Assumption: Every function that steps the iterator does so through this function
     pub fn next(&mut self) -> Option<char> {
@@ -76,7 +76,7 @@ impl<'a> SourceIterator<'a> {
         // when self.src runs out of chars to yield
         match next {
             Some('\n') => {
-                self.next_location.as_mut().unwrap().row += 1;
+                self.next_location.as_mut().unwrap().line += 1;
                 self.next_location.as_mut().unwrap().col = 1;
             }
             Some(_) => self.next_location.as_mut().unwrap().col += 1,
@@ -149,16 +149,16 @@ mod tests {
     }
 
     #[test]
-    fn row_count() {
-        let mut iter = SourceIterator::new("row 1\nrow 2\nrow 3");
+    fn line_count() {
+        let mut iter = SourceIterator::new("line 1\nline 2\nline 3");
         iter.skip(1);
-        assert_eq!(iter.loc().map(|loc| loc.row), Some(1));
-        iter.skip(6);
-        assert_eq!(iter.loc().map(|loc| loc.row), Some(2));
-        iter.skip(6);
-        assert_eq!(iter.loc().map(|loc| loc.row), Some(3));
-        iter.skip(4);
-        assert_eq!(iter.loc().map(|loc| loc.row), Some(3));
+        assert_eq!(iter.loc().map(|loc| loc.line), Some(1));
+        iter.skip(7);
+        assert_eq!(iter.loc().map(|loc| loc.line), Some(2));
+        iter.skip(7);
+        assert_eq!(iter.loc().map(|loc| loc.line), Some(3));
+        iter.skip(5);
+        assert_eq!(iter.loc().map(|loc| loc.line), Some(3));
         iter.skip(1);
         assert_eq!(iter.next(), None);
         assert_eq!(iter.loc(), None);

--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -15,7 +15,7 @@ use crate::lexer::Punctuation::{
     Equals, Exclamation, Hashtag, Newline, OpenBracket, Percent, Pipe, Plus, Question, SingleQuote,
     Slash, Tilde,
 };
-use crate::lexer::{Error, Result, Token};
+use crate::lexer::{Error, ErrorKind, Result, Token};
 
 #[derive(Debug)]
 pub struct Tokens<'a> {
@@ -39,55 +39,47 @@ impl<'a> Iterator for Tokens<'a> {
             .skip_while(|c| c.is_ascii_whitespace() && c != '\n');
 
         let tok = match self.src.peek()? {
-            '&' => Ok(Token::Punctuation(Ampersand)),
-            '*' => Ok(Token::Punctuation(Asterisk)),
-            '@' => Ok(Token::Punctuation(At)),
-            '\\' => Ok(Token::Punctuation(Backslash)),
-            '^' => Ok(Token::Punctuation(Caret)),
-            ':' => Ok(Token::Punctuation(Colon)),
-            ',' => Ok(Token::Punctuation(Comma)),
-            '-' => Ok(Token::Punctuation(Dash)),
-            '$' => Ok(Token::Punctuation(Dollar)),
-            '.' => Ok(Token::Punctuation(Dot)),
-            '=' => Ok(Token::Punctuation(Equals)),
-            '!' => Ok(Token::Punctuation(Exclamation)),
-            '#' => Ok(Token::Punctuation(Hashtag)),
-            '\n' => Ok(Token::Punctuation(Newline)),
-            '%' => Ok(Token::Punctuation(Percent)),
-            '|' => Ok(Token::Punctuation(Pipe)),
-            '+' => Ok(Token::Punctuation(Plus)),
-            '?' => Ok(Token::Punctuation(Question)),
-            '\'' => Ok(Token::Punctuation(SingleQuote)),
-            '~' => Ok(Token::Punctuation(Tilde)),
-
-            '<' => Ok(Token::Punctuation(OpenBracket(Angle))),
-            '>' => Ok(Token::Punctuation(CloseBracket(Angle))),
-            '{' => Ok(Token::Punctuation(OpenBracket(Curly))),
-            '}' => Ok(Token::Punctuation(CloseBracket(Curly))),
-            '(' => Ok(Token::Punctuation(OpenBracket(Round))),
-            ')' => Ok(Token::Punctuation(CloseBracket(Round))),
-            '[' => Ok(Token::Punctuation(OpenBracket(Square))),
-            ']' => Ok(Token::Punctuation(CloseBracket(Square))),
-
             '/' => Ok(self.read_slash_or_comment()),
             '"' => self.read_str_literal(),
 
             c if c.is_ascii_digit() => self.read_numeric_literal(),
             c if c.is_alphabetic() || c == '_' => Ok(self.read_identifier_or_kw()),
 
-            c => Err(Error::new(self.src.loc(), UnknownStartOfToken(c))),
-        };
+            // otherwise, consume the peeked char
+            _ => match self.src.next().unwrap() {
+                '&' => Ok(Token::Punctuation(Ampersand)),
+                '*' => Ok(Token::Punctuation(Asterisk)),
+                '@' => Ok(Token::Punctuation(At)),
+                '\\' => Ok(Token::Punctuation(Backslash)),
+                '^' => Ok(Token::Punctuation(Caret)),
+                ':' => Ok(Token::Punctuation(Colon)),
+                ',' => Ok(Token::Punctuation(Comma)),
+                '-' => Ok(Token::Punctuation(Dash)),
+                '$' => Ok(Token::Punctuation(Dollar)),
+                '.' => Ok(Token::Punctuation(Dot)),
+                '=' => Ok(Token::Punctuation(Equals)),
+                '!' => Ok(Token::Punctuation(Exclamation)),
+                '#' => Ok(Token::Punctuation(Hashtag)),
+                '\n' => Ok(Token::Punctuation(Newline)),
+                '%' => Ok(Token::Punctuation(Percent)),
+                '|' => Ok(Token::Punctuation(Pipe)),
+                '+' => Ok(Token::Punctuation(Plus)),
+                '?' => Ok(Token::Punctuation(Question)),
+                '\'' => Ok(Token::Punctuation(SingleQuote)),
+                '~' => Ok(Token::Punctuation(Tilde)),
 
-        match tok {
-            Ok(Token::Punctuation(Slash)) => {}
-            Ok(Token::Punctuation(_)) => self.src.skip(1),
-            Err(Error {
-                row: _,
-                col: _,
-                kind: UnknownStartOfToken(_),
-            }) => self.src.skip(1),
-            _ => {}
-        }
+                '<' => Ok(Token::Punctuation(OpenBracket(Angle))),
+                '>' => Ok(Token::Punctuation(CloseBracket(Angle))),
+                '{' => Ok(Token::Punctuation(OpenBracket(Curly))),
+                '}' => Ok(Token::Punctuation(CloseBracket(Curly))),
+                '(' => Ok(Token::Punctuation(OpenBracket(Round))),
+                ')' => Ok(Token::Punctuation(CloseBracket(Round))),
+                '[' => Ok(Token::Punctuation(OpenBracket(Square))),
+                ']' => Ok(Token::Punctuation(CloseBracket(Square))),
+
+                c => Err(self.create_error(UnknownStartOfToken(c))),
+            },
+        };
 
         Some(tok)
     }
@@ -123,7 +115,7 @@ impl<'a> Tokens<'a> {
 
         loop {
             match self.src.peek() {
-                Some('\n') | None => return Err(Error::new(self.src.loc(), UnterminatedStr)),
+                Some('\n') | None => return Err(self.create_error(UnterminatedStr)),
                 Some('"') => {
                     self.src.skip(1);
                     let default = Ok(Token::Literal(StrLiteral(contents)));
@@ -153,8 +145,8 @@ impl<'a> Tokens<'a> {
             Some('"') => Ok('"'),
             Some('u') => self.take_hex_code_and_conv_to_char(4),
             Some('x') => self.take_hex_code_and_conv_to_char(2),
-            Some(c) => Err(Error::new(self.src.loc(), UnknownEscape(c))),
-            None => Err(Error::new(self.src.loc(), UnterminatedStr)),
+            Some(c) => Err(self.create_error(UnknownEscape(c))),
+            None => Err(self.create_error(UnterminatedStr)),
             // todo newline!
         }
     }
@@ -171,18 +163,18 @@ impl<'a> Tokens<'a> {
                     self.src.skip(1);
                     code.push(c);
                 }
-                Some('"') => return Err(Error::new(self.src.loc(), TruncatedEscapeSequence)),
+                Some('"') => return Err(self.create_error(TruncatedEscapeSequence)),
                 Some(c) => {
                     self.src.skip(1);
-                    return Err(Error::new(self.src.loc(), InvalidCharInEscape(c)));
+                    return Err(self.create_error(InvalidCharInEscape(c)));
                 }
-                None => return Err(Error::new(self.src.loc(), UnterminatedStr)),
+                None => return Err(self.create_error(UnterminatedStr)),
             }
         }
         // It is safe to unwrap from_str_radix(), which panics if radix > 36 (ours is 16)
         match char::from_u32(u32::from_str_radix(&code, 16).unwrap()) {
             Some(c) => Ok(c),
-            None => Err(Error::new(self.src.loc(), BadUnicodeEscape(code))),
+            None => Err(self.create_error(BadUnicodeEscape(code))),
         }
     }
 
@@ -209,12 +201,17 @@ impl<'a> Tokens<'a> {
         if num.contains(['e', 'E', '.']) {
             match num.parse() {
                 Ok(parsed) => Ok(Token::Literal(FloatLiteral(parsed))),
-                Err(_) => Err(Error::new(self.src.loc(), InvalidFloat(num))),
+                Err(_) => Err(self.create_error(InvalidFloat(num))),
             }
         } else {
             // This is safe to unwrap because we can't get an invalid int
             Ok(Token::Literal(IntLiteral(num.parse().unwrap())))
         }
+    }
+
+    fn create_error(&self, kind: ErrorKind) -> Error {
+        // Safe to unwrap self.src.loc() because we never throw errors after self.src returns None
+        Error::new(self.src.loc().unwrap(), kind)
     }
 
     /// Returns next identifier or keyword consisting of alphabetic letters, digits,
@@ -273,14 +270,14 @@ mod tests {
     #[test]
     fn err_given_unknown_str_escape() {
         let source = r#""\e""#;
-        let expected = vec![Err(Error::new((1, 4), UnknownEscape('e')))];
+        let expected = vec![Err(Error::new((1, 3), UnknownEscape('e')))];
         assert_source_has_expected_output!(&source.to_string(), expected)
     }
 
     #[test]
     fn err_given_truncated_unicode_escape() {
         let source = r#""\u3b9""#;
-        let expected = vec![Err(Error::new((1, 7), TruncatedEscapeSequence))];
+        let expected = vec![Err(Error::new((1, 6), TruncatedEscapeSequence))];
         assert_source_has_expected_output!(&source.to_string(), expected)
     }
 
@@ -294,7 +291,7 @@ mod tests {
     #[test]
     fn err_given_truncated_hex_escape() {
         let source = r#""\x9""#;
-        let expected = vec![Err(Error::new((1, 5), TruncatedEscapeSequence))];
+        let expected = vec![Err(Error::new((1, 4), TruncatedEscapeSequence))];
         assert_source_has_expected_output!(&source.to_string(), expected)
     }
 


### PR DESCRIPTION
This adds support for line numbers to our feature-iterator branch. This adds a custom iterator that internally keeps track of our location in the program. Whenever we create an Error we also give it the location from our iterator.