### PR TITLE
Implement negative integer literals

### DIFF
--- a/src/lexing/lexer.rs
+++ b/src/lexing/lexer.rs
@@ -90,7 +90,8 @@ impl<'a> Lexer<'a> {
         // Figure out what type the next token is and call handling function
         let peeked_token = match (self.peek_char(1)?, self.peek_char(2)) {
             ('a'..='z' | 'A'..='Z' | '_', _) => return Some(self.read_word()),
-            ('0'..='9', _) => return Some(self.read_i64_literal()),
+            ('0'..='9', _) => return Some(self.read_int_literal()),
+            ('-', Some('0'..='9')) => return Some(self.read_int_literal()),
             ('/', Some('/')) => return Some(self.read_comment()),
 
             ('>', Some('=')) => Token::ComparatorSymbol(GreaterOrEqualTo),
@@ -190,10 +191,10 @@ impl<'a> Lexer<'a> {
     ///
     /// # Assumptions:
     ///
-    /// - The next source code character is a digit.
-    fn read_i64_literal(&mut self) -> Token {
-        // TODO: Allow negative numbers
-        let number = self.take_chars_while(|&c| c.is_ascii_digit());
+    /// - The next source code character is a digit or a '-'
+    fn read_int_literal(&mut self) -> Token {
+        let mut number = self.next_char().expect("function assumes >0 chars in source").to_string();
+        number.push_str(&self.take_chars_while(|&c| c.is_ascii_digit()));
         Token::IntLiteral(number)
     }
 

--- a/src/lexing/token.rs
+++ b/src/lexing/token.rs
@@ -4,9 +4,9 @@ use std::fmt;
 /// An enum to represent any given non-whitespace token in a source code
 ///
 /// For example, `foo(42)` consists of four tokens:
-/// 1. `Token::Identifier("print")`
+/// 1. `Token::Identifier("foo".to_string())`
 /// 1. `Token::LParen`
-/// 1. `Token::I64Literal(42)`
+/// 1. `Token::IntLiteral("42".to_string())`
 /// 1. `Token::RParen`
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Token {


### PR DESCRIPTION
Add support for negative integer literals.

Note: there is an issue where an expression like `5 -3` gets parsed as two distinct numbers. This maybe should be parsed as a binary expression, so worth revisiting at some point. For now, it is a design decision.