### PR TITLE
Add `extern` keyword

### DIFF
--- a/examples/extern.fl
+++ b/examples/extern.fl
@@ -1,0 +1,11 @@
+extern fn srand(i8 seed)
+extern fn putchar(i8 c) i8
+
+
+pub fn main() {
+    i64 x = 4
+    if x > 3 {
+        i8 d = putchar(72)
+    }
+    ret
+}

--- a/examples/hello_world.fl
+++ b/examples/hello_world.fl
@@ -1,0 +1,17 @@
+extern fn putchar(i8 c) i8
+
+pub fn main() {
+    i8 a = putchar(72)
+    i8 a = putchar(101)
+    i8 a = putchar(108)
+    i8 a = putchar(108)
+    i8 a = putchar(111)
+    i8 a = putchar(32)
+    i8 a = putchar(119)
+    i8 a = putchar(111)
+    i8 a = putchar(114)
+    i8 a = putchar(108)
+    i8 a = putchar(100)
+    i8 a = putchar(10)
+}
+

--- a/examples/return_in_while_loop.fl
+++ b/examples/return_in_while_loop.fl
@@ -1,7 +1,8 @@
 pub fn main() i64 {
     i64 i = 0
-    while i < 10 {
-        i += 1
-        ret i
-    }
+    ret i
+    //while i < 10 {
+    //    i += 1
+    //    ret i
+    //}
 }

--- a/examples/return_in_while_loop.fl
+++ b/examples/return_in_while_loop.fl
@@ -1,8 +1,8 @@
 pub fn main() i64 {
     i64 i = 0
-    ret i
     //while i < 10 {
     //    i += 1
     //    ret i
     //}
+    ret i
 }

--- a/examples/simple_while_loop.fl
+++ b/examples/simple_while_loop.fl
@@ -1,5 +1,5 @@
-pub fn main() i12 {
-    i12 i = 1
+pub fn main() i64 {
+    i64 i = 1
     while i < 10 {
         i += 1
     }

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -14,8 +14,16 @@ if ! RUSTDOCFLAGS="-D warnings" cargo doc --no-deps; then
   exit 1
 fi
 
-if ! cargo build && target/debug/flick examples/*.fl; then
-  printf "\n"
-  echo "Some programs don't compile; aborting commit"
-  exit 1
+if ! cargo build; then
+    printf "\n"
+    echo "Couldn't build; aborting commit"
+    exit 1
 fi
+
+for FLICK_SRC_FILE in examples/*.fl; do
+  if ! target/debug/flick $FLICK_SRC_FILE; then
+    printf "\n"
+    echo "$FLICK_SRC_FILE does not compile; aborting commit"
+    exit 1
+  fi
+done

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -13,3 +13,9 @@ if ! RUSTDOCFLAGS="-D warnings" cargo doc --no-deps; then
   echo "Docs don't build correctly; aborting commit"
   exit 1
 fi
+
+if ! cargo build && target/debug/flick examples/*.fl; then
+  printf "\n"
+  echo "Some programs don't compile; aborting commit"
+  exit 1
+fi

--- a/src/lexing/lexer.rs
+++ b/src/lexing/lexer.rs
@@ -182,6 +182,7 @@ impl<'a> Lexer<'a> {
             "fn" => Token::Fn,
             "ret" => Token::Ret,
             "if" => Token::If,
+            "extern" => Token::Extern,
             "else" => Token::Else,
             _ => Token::Identifier(s),
         }

--- a/src/lexing/token.rs
+++ b/src/lexing/token.rs
@@ -17,10 +17,11 @@ pub enum Token {
     Identifier(String),
 
     // Keywords
+    Extern,
     Pub,
     Fn,
-    While,
     Ret,
+    While,
     If,
     Else,
 
@@ -62,6 +63,7 @@ impl fmt::Display for Token {
 
             Self::Pub => write!(f, "pub"),
             Self::Fn => write!(f, "fn"),
+            Self::Extern => write!(f, "extern"),
             Self::While => write!(f, "while"),
             Self::Ret => write!(f, "ret"),
             Self::If => write!(f, "if"),

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -4,10 +4,19 @@ use crate::lexing::token::{ComparatorSymbol, OperatorSymbol};
 use crate::Type;
 use std::fmt;
 
-/// A program; a collection of function definitions. See also: [FuncDef].
+/// A program consisting of at least one [GlobalStatement].
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Program {
-    pub func_defs: Vec<FuncDef>,
+    pub global_statements: Vec<GlobalStatement>
+}
+
+/// A global statement is something that can be written in the "global" scope, as opposed
+/// to inside of a function body. So, for example, function definitions and external function
+/// declarations are "global" statements.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum GlobalStatement {
+    Extern(FuncProto),
+    FuncDef(FuncDef),
 }
 
 /// A function definition (metadata, prototype, and body).
@@ -20,10 +29,18 @@ pub struct FuncDef {
 /// A function prototype (name, parameters, and return type).
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct FuncProto {
-    pub is_public: bool,
+    pub func_visibility: FuncVisibility,
     pub name: String,
     pub params: Vec<FuncParam>,
     pub return_type: Type,
+}
+
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum FuncVisibility {
+    Public,
+    Private,
+    Extern
 }
 
 /// A function parameter (its name and its data type).

--- a/src/typing/typed_ast.rs
+++ b/src/typing/typed_ast.rs
@@ -2,13 +2,20 @@ use crate::ast::{BinaryOperator, ComparisonOperator, FuncProto};
 use crate::types::{FuncType, IntType};
 use crate::Type;
 
-/// A program; a collection of function definitions. See also: [TypedFuncDef].
+/// A typed version of [Program](crate::ast::Program)
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypedProgram {
-    pub func_defs: Vec<TypedFuncDef>,
+    pub global_statements: Vec<TypedGlobalStatement>,
 }
 
-/// A function definition (metadata, prototype, and body).
+/// A typed version of [GlobalStatement](crate::ast::GlobalStatement)
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum TypedGlobalStatement {
+    Extern(FuncProto),
+    FuncDef(TypedFuncDef)
+}
+
+/// A typed version of [crate::ast::FuncDef]
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypedFuncDef {
     pub proto: FuncProto,
@@ -22,23 +29,7 @@ pub struct TypedFuncParam {
     pub param_name: String,
 }
 
-/// A statement (the equivalent of 'a line of code').
-///
-/// Statements do not evaluate to any particular value, but they have side effects. For
-/// example, consider the following code:
-///
-/// ```text
-/// i64 i = 0  // this is a statement
-/// if should_change_i() (
-///     i = 1  // this is a statement
-/// }
-/// ```
-///
-/// Each line is a statement. Note, `i = 1` is also technically an expression that
-/// evaluates to `1`. However, since we are not using the value of `i = 1` when we write
-/// `i = 1`, our code becomes a statement.
-///
-/// See also: [TypedExpr].
+/// A typed version of [Statement](crate::ast::Statement).
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TypedStatement {
     VarDeclaration(TypedVarDeclaration),
@@ -49,11 +40,7 @@ pub enum TypedStatement {
     If(TypedIf),
 }
 
-/// A variable declaration and, optionally, variable definition as well.
-///
-/// This struct stores the name and type of the declared variable, as well as its
-/// value (if the variable declaration comes with an assignment, like `int a = 7;` instead of
-/// `int a;`).
+/// A typed version of [VarDeclaration](crate::ast::VarDeclaration)
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypedVarDeclaration {
     pub var_name: String,
@@ -61,14 +48,14 @@ pub struct TypedVarDeclaration {
     pub var_value: TypedExpr,
 }
 
-/// A typed version of [crate::ast::WhileLoop].
+/// A typed version of [WhileLoop](crate::ast::WhileLoop).
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypedWhileLoop {
     pub condition: TypedExpr,
     pub body: Vec<TypedStatement>,
 }
 
-/// A typed version of [crate::ast::If].
+/// A typed version of [If](crate::ast::If).
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypedIf {
     pub condition: TypedExpr,
@@ -76,9 +63,7 @@ pub struct TypedIf {
     pub else_body: Option<Vec<TypedStatement>>,
 }
 
-/// An expression, which is any piece of code that has a value.
-///
-/// For example, `current_length` or `1 + 2` or `foo("bye")` are expressions.
+/// A typed version of [Expr](crate::ast::Expr)
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum TypedExpr {
     Identifier(TypedIdentifier),
@@ -88,19 +73,14 @@ pub enum TypedExpr {
     Call(TypedCall),
 }
 
-/// An assignment expression (the variable name and the new value).
+/// A typed version of [Assignment](crate::ast::Assignment).
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypedAssignment {
     pub name: String,
     pub value: Box<TypedExpr>,
 }
 
-/// A binary expression (the operator and the left/right-hand sides).
-///
-/// For example, `a + foo(1)` breaks down into:
-/// - left: `a`
-/// - operator: `+`
-/// - right: `foo(1)`
+/// A typed version of [Binary](crate::ast::Binary).
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypedBinary {
     pub left: Box<TypedExpr>,
@@ -109,7 +89,7 @@ pub struct TypedBinary {
     pub result_type: Type,
 }
 
-/// An integer literal
+/// A typed version of [IntLiteral](crate::ast::Expr::IntLiteral)
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypedIntLiteral {
     pub int_value: String,


### PR DESCRIPTION
- Allow external function declarations as global statements (e.g. `extern fn ...`)
  - This allows us to introduce more global statements in the future
  - This also allows us to import libc functions, so we can print `Hello world` for the first time!
- Make sure that all example programs compile before committing
- Fix bugs