### PR TITLE
Fixed support for negative numbers

### DIFF
--- a/examples/negative_numbers.fl
+++ b/examples/negative_numbers.fl
@@ -1,0 +1,5 @@
+pub fn main() i32 {
+    i32 a = -1
+    i32 b = 5 -2 - a
+    ret b
+}

--- a/src/compilation/compiler.rs
+++ b/src/compilation/compiler.rs
@@ -462,9 +462,17 @@ impl Compiler {
     }
 
     /// Compiles an integer literal expression.
+    /// 
+    /// This function converts a `TypedIntLiteral` into an LLVM constant integer value.
+    /// If `int_literal.negative` is true, the value is negated.
     unsafe fn compile_int_literal(&self, int_literal: &TypedIntLiteral) -> LLVMValueRef {
         let int_type = self.to_llvm_type(&Type::Int(int_literal.int_type));
-        let value_cstr = CString::new(int_literal.int_value.as_str()).unwrap();
+        let value_str = if int_literal.negative {
+            format!("-{}", int_literal.int_value)
+        } else {
+            int_literal.int_value.clone()
+        };
+        let value_cstr = CString::new(value_str).unwrap();
         LLVMConstIntOfString(int_type, value_cstr.as_ptr(), 10)
     }
 

--- a/src/compilation/compiler.rs
+++ b/src/compilation/compiler.rs
@@ -467,10 +467,9 @@ impl Compiler {
     /// If `int_literal.negative` is true, the value is negated.
     unsafe fn compile_int_literal(&self, int_literal: &TypedIntLiteral) -> LLVMValueRef {
         let int_type = self.to_llvm_type(&Type::Int(int_literal.int_type));
-        let value_str = if int_literal.negative {
-            format!("-{}", int_literal.int_value)
-        } else {
-            int_literal.int_value.clone()
+        let value_str = match int_literal.negative {
+            true => format!("-{}", int_literal.int_value),
+            false => int_literal.int_value.clone(),
         };
         let value_cstr = CString::new(value_str).unwrap();
         LLVMConstIntOfString(int_type, value_cstr.as_ptr(), 10)

--- a/src/lexing/lexer.rs
+++ b/src/lexing/lexer.rs
@@ -91,7 +91,6 @@ impl<'a> Lexer<'a> {
         let peeked_token = match (self.peek_char(1)?, self.peek_char(2)) {
             ('a'..='z' | 'A'..='Z' | '_', _) => return Some(self.read_word()),
             ('0'..='9', _) => return Some(self.read_int_literal()),
-            ('-', Some('0'..='9')) => return Some(self.read_int_literal()),
             ('/', Some('/')) => return Some(self.read_comment()),
 
             ('>', Some('=')) => Token::ComparatorSymbol(GreaterOrEqualTo),
@@ -194,8 +193,7 @@ impl<'a> Lexer<'a> {
     ///
     /// - The next source code character is a digit or a '-'
     fn read_int_literal(&mut self) -> Token {
-        let mut number = self.next_char().expect("function assumes >0 chars in source").to_string();
-        number.push_str(&self.take_chars_while(|&c| c.is_ascii_digit()));
+        let number = self.take_chars_while(|&c| c.is_ascii_digit());
         Token::IntLiteral(number)
     }
 

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -114,7 +114,7 @@ pub struct WhileLoop {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Expr {
     Identifier(String),
-    IntLiteral(String),
+    IntLiteral(IntLiteral),
     Binary(Binary),
     Comparison(Comparison),
     Call(Call),
@@ -125,6 +125,24 @@ pub enum Expr {
 pub struct Assignment {
     pub name: String,
     pub value: Box<Expr>,
+}
+
+/// An integer literal, which represents a constant integer value in the source code.
+///
+/// For example, `42` or `-42` are integer literals.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct IntLiteral {
+    pub negative: bool,
+    pub value: String,
+}
+
+impl fmt::Display for IntLiteral {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.negative {
+            write!(f, "-")?;
+        }
+        write!(f, "{}", self.value)
+    }
 }
 
 /// A binary expression (the operator and the left/right-hand sides).

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -12,13 +12,13 @@
 /// # let _ =
 /// Expr::Binary(
 ///     Binary {
-///         left: Box::new(Expr::IntLiteral("9".to_string())),
+///         left: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "9".to_string() })),
 ///         operator: BinaryOperator::Multiply,
 ///         right: Box::new(Expr::Binary(
 ///             Binary {
-///                 left: Box::new(Expr::IntLiteral("2".to_string())),
+///                 left: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "2".to_string() })),
 ///                 operator: BinaryOperator::Add,
-///                 right: Box::new(Expr::IntLiteral("3".to_string())),
+///                 right: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "3".to_string() })),
 ///             }
 ///         )),
 ///     }

--- a/src/typing/typed_ast.rs
+++ b/src/typing/typed_ast.rs
@@ -92,6 +92,7 @@ pub struct TypedBinary {
 /// A typed version of [IntLiteral](crate::ast::Expr::IntLiteral)
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypedIntLiteral {
+    pub negative: bool,
     pub int_value: String,
     pub int_type: IntType,
 }

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -1,5 +1,5 @@
 use crate::ast::{
-    Assignment, Binary, Call, Comparison, Expr, FuncDef, FuncProto, GlobalStatement, If, Program, Statement, VarDeclaration, WhileLoop
+    Assignment, Binary, Call, Comparison, Expr, FuncDef, FuncProto, GlobalStatement, If, IntLiteral, Program, Statement, VarDeclaration, WhileLoop
 };
 use crate::scope_manager::ScopeManager;
 use crate::typed_ast::{
@@ -266,7 +266,7 @@ impl Typer {
 
     /// Checks that `desired_type` is a valid type (namely, an integer type) and wraps the
     /// `int_literal` as a `TypedIntLiteral`.
-    fn type_int_literal(&self, int_literal: &str, desired_type: Option<&Type>) -> TypedIntLiteral {
+    fn type_int_literal(&self, int_literal: &IntLiteral, desired_type: Option<&Type>) -> TypedIntLiteral {
         let int_type = match desired_type {
             Some(Type::Int(int_type)) => *int_type,
             Some(t) => {
@@ -279,7 +279,8 @@ impl Typer {
         };
 
         TypedIntLiteral {
-            int_value: int_literal.to_string(),
+            negative: int_literal.negative,
+            int_value: int_literal.value.clone(),
             int_type,
         }
     }
@@ -438,12 +439,12 @@ mod tests {
                 body: vec![
                     Statement::VarDeclaration(VarDeclaration {
                         var_name: "a".to_string(),
-                        var_value: Expr::IntLiteral("3".to_string()),
+                        var_value: Expr::IntLiteral(IntLiteral { negative: false, value: "3".to_string() }),
                         var_type: Type::Int(IntType { width: 64 }),
                     }),
                     Statement::VarDeclaration(VarDeclaration {
                         var_name: "b".to_string(),
-                        var_value: Expr::IntLiteral("a".to_string()),
+                        var_value: Expr::Identifier("a".to_string()),
                         var_type: Type::Int(IntType { width: 64 }),
                     }),
                     Statement::VarDeclaration(VarDeclaration {
@@ -478,12 +479,12 @@ mod tests {
                 body: vec![
                     Statement::VarDeclaration(VarDeclaration {
                         var_name: "a".to_string(),
-                        var_value: Expr::IntLiteral("3".to_string()),
+                        var_value: Expr::IntLiteral(IntLiteral { negative: false, value: "3".to_string() }),
                         var_type: Type::Int(IntType { width: 32 }),
                     }),
                     Statement::VarDeclaration(VarDeclaration {
                         var_name: "b".to_string(),
-                        var_value: Expr::IntLiteral("a".to_string()),
+                        var_value: Expr::Identifier("a".to_string()),
                         var_type: Type::Int(IntType { width: 32 }),
                     }),
                     Statement::Return(Some(Expr::Identifier("b".to_string()))),
@@ -503,6 +504,7 @@ mod tests {
                     TypedStatement::VarDeclaration(TypedVarDeclaration {
                         var_name: "a".to_string(),
                         var_value: TypedExpr::IntLiteral(TypedIntLiteral {
+                            negative: false,
                             int_value: "3".to_string(),
                             int_type: IntType { width: 32 },
                         }),
@@ -510,11 +512,11 @@ mod tests {
                     }),
                     TypedStatement::VarDeclaration(TypedVarDeclaration {
                         var_name: "b".to_string(),
-                        var_value: TypedExpr::IntLiteral(TypedIntLiteral {
-                            int_value: "a".to_string(),
-                            int_type: IntType { width: 32 },
-                        }),
                         var_type: Type::Int(IntType { width: 32 }),
+                        var_value: TypedExpr::Identifier(TypedIdentifier {
+                            name: "a".to_string(),
+                            id_type: Type::Int(IntType { width: 32 }),
+                        }),
                     }),
                     TypedStatement::Return(Some(TypedExpr::Identifier(TypedIdentifier {
                         name: "b".to_string(),


### PR DESCRIPTION
As mentioned in pr #17, the way we handled negative int literals (which was in lexer) would fail when parsing something like `5 -3`. The reason that happens is because the lexer lexes that as two separate int literals.

The issue here was that we were handling negative numbers in the lexer. By doing that, we lost all information of whether the number was negative or not, and what tokens surrounded it. The negative number parsing is actually supposed to happen in the AST parser, because the parser has the context of surrounding tokens. Since binary expressions have parsing precedence, the parser now parses the above example correctly. 

The parser now stores a new `negative` field alongside the int value, and the int type. This provides a nice advantage for later when we add unsigned integers because we can check in typer to make sure the int literal is not negative when assigning to an unsigned type. We could not have done this before (nicely) using the lexer.