### PR TITLE
Fix return in block

### DIFF
--- a/examples/return_in_while_loop.fl
+++ b/examples/return_in_while_loop.fl
@@ -1,8 +1,8 @@
 pub fn main() i64 {
     i64 i = 0
-    //while i < 10 {
-    //    i += 1
-    //    ret i
-    //}
+    while i < 10 {
+        i += 1
+        ret i
+    }
     ret i
 }


### PR DESCRIPTION
This pull request fixes a compiler bug that would generate invalid LLVM IR for Flick programs that have `ret` statements inside of `if` and `while` blocks. 

Broadly speaking, the issue was that LLVM IR requires each basic block to end with a `return` or `branch` instruction, not both, and so some extra processing is required to ensure that the generated IR is valid.