### PR TITLE
Add unsigned integers

### DIFF
--- a/examples/extern.fl
+++ b/examples/extern.fl
@@ -3,7 +3,7 @@ extern fn putchar(i8 c) i8
 
 
 pub fn main() {
-    i64 x = 4
+    u64 x = 4
     if x > 3 {
         i8 d = putchar(72)
     }

--- a/examples/return_in_while_loop.fl
+++ b/examples/return_in_while_loop.fl
@@ -1,5 +1,5 @@
-pub fn main() i64 {
-    i64 i = 0
+pub fn main() u64 {
+    u64 i = 0
     while i < 10 {
         i += 1
         ret i

--- a/examples/simple_while_loop.fl
+++ b/examples/simple_while_loop.fl
@@ -1,5 +1,5 @@
-pub fn main() i64 {
-    i64 i = 1
+pub fn main() u64 {
+    u64 i = 1
     while i < 10 {
         i += 1
     }

--- a/examples/unsigned_ints.fl
+++ b/examples/unsigned_ints.fl
@@ -1,0 +1,10 @@
+pub fn main() i8 {
+    i8 a = 130
+    i8 b = 120
+    if a < b {
+        ret 1
+    } else {
+        ret -1
+    }
+    ret 0
+}

--- a/src/compilation/compiler.rs
+++ b/src/compilation/compiler.rs
@@ -510,7 +510,7 @@ impl Compiler {
             Divide => match bin_expr.result_type {
                 Type::Int(IntType { signed: true, .. }) => LLVMBuildSDiv(self.builder, lhs, rhs, cstr!("sdiv")),
                 Type::Int(IntType { signed: false, .. }) => LLVMBuildUDiv(self.builder, lhs, rhs, cstr!("udiv")),
-                _ => panic!("Division should've been handled by Typer"),
+                _ => panic!("We can't divide non-integers"),
             },
         }
     }

--- a/src/compilation/compiler.rs
+++ b/src/compilation/compiler.rs
@@ -4,7 +4,8 @@ use std::ffi::{c_char, c_uint, CStr, CString};
 use std::mem::MaybeUninit;
 use std::path::Path;
 
-use llvm_sys::{core::*, LLVMIntPredicate};
+use llvm_sys::core::*;
+use llvm_sys::core::LLVMIntPredicate;
 use llvm_sys::error::LLVMGetErrorMessage;
 use llvm_sys::prelude::*;
 use llvm_sys::target::{

--- a/src/compilation/compiler.rs
+++ b/src/compilation/compiler.rs
@@ -502,15 +502,19 @@ impl Compiler {
             panic!("Binary expr: type(LHS) != type(RHS) should've been handled by Typer")
         }
 
+        let int_type = match bin_expr.result_type {
+            Type::Int(int_type) => int_type,
+            _ => panic!("Unsupported lhs and rhs types for binary expr; can only handle integers"),
+        };
+
         match bin_expr.operator {
             Add => LLVMBuildAdd(self.builder, lhs, rhs, cstr!("add")),
             Subtract => LLVMBuildSub(self.builder, lhs, rhs, cstr!("sub")),
             Multiply => LLVMBuildMul(self.builder, lhs, rhs, cstr!("mul")),
             // TODO: signed-ints: Signed vs unsigned division
-            Divide => match bin_expr.result_type {
-                Type::Int(IntType { signed: true, .. }) => LLVMBuildSDiv(self.builder, lhs, rhs, cstr!("sdiv")),
-                Type::Int(IntType { signed: false, .. }) => LLVMBuildUDiv(self.builder, lhs, rhs, cstr!("udiv")),
-                _ => panic!("We can't divide non-integers"),
+            Divide => match int_type {
+                IntType { signed: true, .. } => LLVMBuildSDiv(self.builder, lhs, rhs, cstr!("sdiv")),
+                IntType { signed: false, .. } => LLVMBuildUDiv(self.builder, lhs, rhs, cstr!("udiv")),
             },
         }
     }

--- a/src/compilation/compiler.rs
+++ b/src/compilation/compiler.rs
@@ -5,7 +5,7 @@ use std::mem::MaybeUninit;
 use std::path::Path;
 
 use llvm_sys::core::*;
-use llvm_sys::core::LLVMIntPredicate;
+use llvm_sys::LLVMIntPredicate;
 use llvm_sys::error::LLVMGetErrorMessage;
 use llvm_sys::prelude::*;
 use llvm_sys::target::{
@@ -530,7 +530,7 @@ impl Compiler {
             panic!("Comparison: type(LHS) != type(RHS) should've been handled by Typer")
         }
 
-        match comparison.result_type {
+        match comparison.operand_type {
             Type::Int(int_type) => LLVMBuildICmp(self.builder, self.comparison_int_op(comparison.operator, int_type), lhs, rhs, cstr!("")),
             _ => panic!("Unsupported lhs and rhs types for comparison; can only handle integers"),
         }

--- a/src/compilation/compiler.rs
+++ b/src/compilation/compiler.rs
@@ -21,7 +21,7 @@ use llvm_sys::target_machine::{
     LLVMTargetMachineRef,
 };
 use llvm_sys::transforms::pass_builder::*;
-use llvm_sys::LLVMLinkage::{LLVMExternalLinkage, LLVMInternalLinkage};
+use llvm_sys::LLVMLinkage::{LLVMExternalLinkage, LLVMInternalLinkage, LLVMAvailableExternallyLinkage};
 
 use crate::ast::*;
 use crate::typed_ast::*;
@@ -247,7 +247,7 @@ impl Compiler {
         match func_proto.func_visibility {
             FuncVisibility::Public => LLVMSetLinkage(func, LLVMExternalLinkage),
             FuncVisibility::Private => LLVMSetLinkage(func, LLVMInternalLinkage),
-            FuncVisibility::Extern => LLVMSetLinkage(func, LLVMExternalLinkage),
+            FuncVisibility::Extern => LLVMSetLinkage(func, LLVMAvailableExternallyLinkage),
         }
 
         // TODO: Design: Remove variable shadowing

--- a/src/compilation/compiler.rs
+++ b/src/compilation/compiler.rs
@@ -22,7 +22,7 @@ use llvm_sys::target_machine::{
     LLVMTargetMachineRef,
 };
 use llvm_sys::transforms::pass_builder::*;
-use llvm_sys::LLVMLinkage::{LLVMExternalLinkage, LLVMInternalLinkage, LLVMAvailableExternallyLinkage};
+use llvm_sys::LLVMLinkage::{LLVMExternalLinkage, LLVMInternalLinkage};
 
 use crate::ast::*;
 use crate::typed_ast::*;
@@ -248,7 +248,7 @@ impl Compiler {
         match func_proto.func_visibility {
             FuncVisibility::Public => LLVMSetLinkage(func, LLVMExternalLinkage),
             FuncVisibility::Private => LLVMSetLinkage(func, LLVMInternalLinkage),
-            FuncVisibility::Extern => LLVMSetLinkage(func, LLVMAvailableExternallyLinkage),
+            FuncVisibility::Extern => LLVMSetLinkage(func, LLVMExternalLinkage),
         }
 
         // TODO: Design: Remove variable shadowing

--- a/src/lexing/lexer.rs
+++ b/src/lexing/lexer.rs
@@ -249,12 +249,12 @@ mod tests {
     fn variables() {
         let source_code = "i64 this_is_a_LONG_VARIABLE_NAME = 5\ni64 shortInt = 5";
         let expected_tokens = vec![
-            Token::Type(Type::Int(IntType { width: 64, signed: true })),
+            Token::Type(Type::Int(IntType { signed: true, width: 64 })),
             Token::Identifier("this_is_a_LONG_VARIABLE_NAME".to_string()),
             Token::AssignmentSymbol(Eq),
             Token::IntLiteral("5".to_string()),
             Token::Newline,
-            Token::Type(Type::Int(IntType { width: 64, signed: true })),
+            Token::Type(Type::Int(IntType { signed: true, width: 64 })),
             Token::Identifier("shortInt".to_string()),
             Token::AssignmentSymbol(Eq),
             Token::IntLiteral("5".to_string()),

--- a/src/lexing/lexer.rs
+++ b/src/lexing/lexer.rs
@@ -168,10 +168,14 @@ impl<'a> Lexer<'a> {
     fn read_word(&mut self) -> Token {
         let s = self.take_chars_while(|&c| c.is_ascii_alphanumeric() || c == '_');
 
-        if s.starts_with('i') && s.len() > 1 && s.chars().skip(1).all(|c| c.is_ascii_digit()) {
+        if (s.starts_with('u') || s.starts_with('i')) && s.len() > 1 && s.chars().skip(1).all(|c| c.is_ascii_digit()) {
             let num: String = s.chars().skip(1).collect();
             let width: u32 = num.parse().unwrap();
-            return Token::Type(Type::Int(IntType { width }));
+            match s.chars().next().unwrap() {
+                'u' => return Token::Type(Type::Int(IntType { width, signed: false })),
+                'i' => return Token::Type(Type::Int(IntType { width, signed: true })),
+                _ => unreachable!(),
+            }
         }
 
         match s.as_str() {
@@ -245,12 +249,12 @@ mod tests {
     fn variables() {
         let source_code = "i64 this_is_a_LONG_VARIABLE_NAME = 5\ni64 shortInt = 5";
         let expected_tokens = vec![
-            Token::Type(Type::Int(IntType { width: 64 })),
+            Token::Type(Type::Int(IntType { width: 64, signed: true })),
             Token::Identifier("this_is_a_LONG_VARIABLE_NAME".to_string()),
             Token::AssignmentSymbol(Eq),
             Token::IntLiteral("5".to_string()),
             Token::Newline,
-            Token::Type(Type::Int(IntType { width: 64 })),
+            Token::Type(Type::Int(IntType { width: 64, signed: true })),
             Token::Identifier("shortInt".to_string()),
             Token::AssignmentSymbol(Eq),
             Token::IntLiteral("5".to_string()),

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -604,14 +604,14 @@ mod tests {
     #[test]
     fn var_declaration() {
         let tokens = vec![
-            Token::Type(Type::Int(IntType { width: 64 })),
+            Token::Type(Type::Int(IntType { width: 64, signed: true })),
             Token::Identifier("x".to_string()),
             Token::AssignmentSymbol(Eq),
             Token::IntLiteral("5".to_string()),
         ];
         let expected = Some(Statement::VarDeclaration(VarDeclaration {
             var_name: "x".to_string(),
-            var_type: Type::Int(IntType { width: 64 }),
+            var_type: Type::Int(IntType { width: 64, signed: true }),
             var_value: Expr::IntLiteral(IntLiteral { negative: false, value: "5".to_string() }),
         }));
 
@@ -799,10 +799,10 @@ mod tests {
             Token::Fn,
             Token::Identifier("test".to_string()),
             Token::LParen,
-            Token::Type(Type::Int(IntType { width: 64 })),
+            Token::Type(Type::Int(IntType { width: 64, signed: true })),
             Token::Identifier("a".to_string()),
             Token::RParen,
-            Token::Type(Type::Int(IntType { width: 64 })),
+            Token::Type(Type::Int(IntType { width: 64, signed: true })),
             Token::LSquirly,
             Token::RSquirly,
         ];
@@ -812,10 +812,10 @@ mod tests {
                     func_visibility: FuncVisibility::Public,
                     name: "test".to_string(),
                     params: vec![FuncParam {
-                        param_type: Type::Int(IntType { width: 64 }),
+                        param_type: Type::Int(IntType { width: 64, signed: true }),
                         param_name: "a".to_string(),
                     }],
-                    return_type: Type::Int(IntType { width: 64 }),
+                    return_type: Type::Int(IntType { width: 64, signed: true }),
                 },
                 body: vec![],
             })],

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -604,14 +604,14 @@ mod tests {
     #[test]
     fn var_declaration() {
         let tokens = vec![
-            Token::Type(Type::Int(IntType { width: 64, signed: true })),
+            Token::Type(Type::Int(IntType { signed: true, width: 64 })),
             Token::Identifier("x".to_string()),
             Token::AssignmentSymbol(Eq),
             Token::IntLiteral("5".to_string()),
         ];
         let expected = Some(Statement::VarDeclaration(VarDeclaration {
             var_name: "x".to_string(),
-            var_type: Type::Int(IntType { width: 64, signed: true }),
+            var_type: Type::Int(IntType { signed: true, width: 64 }),
             var_value: Expr::IntLiteral(IntLiteral { negative: false, value: "5".to_string() }),
         }));
 
@@ -799,10 +799,10 @@ mod tests {
             Token::Fn,
             Token::Identifier("test".to_string()),
             Token::LParen,
-            Token::Type(Type::Int(IntType { width: 64, signed: true })),
+            Token::Type(Type::Int(IntType { signed: true, width: 64 })),
             Token::Identifier("a".to_string()),
             Token::RParen,
-            Token::Type(Type::Int(IntType { width: 64, signed: true })),
+            Token::Type(Type::Int(IntType { signed: true, width: 64 })),
             Token::LSquirly,
             Token::RSquirly,
         ];
@@ -812,10 +812,10 @@ mod tests {
                     func_visibility: FuncVisibility::Public,
                     name: "test".to_string(),
                     params: vec![FuncParam {
-                        param_type: Type::Int(IntType { width: 64, signed: true }),
+                        param_type: Type::Int(IntType { signed: true, width: 64 }),
                         param_name: "a".to_string(),
                     }],
-                    return_type: Type::Int(IntType { width: 64, signed: true }),
+                    return_type: Type::Int(IntType { signed: true, width: 64 }),
                 },
                 body: vec![],
             })],

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,8 +22,8 @@ impl fmt::Display for Type {
 /// An enum to store the built-in int type
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct IntType {
-    pub width: u32,
     pub signed: bool,
+    pub width: u32,
 }
 
 impl fmt::Display for IntType {

--- a/src/types.rs
+++ b/src/types.rs
@@ -23,11 +23,15 @@ impl fmt::Display for Type {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct IntType {
     pub width: u32,
+    pub signed: bool,
 }
 
 impl fmt::Display for IntType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "i{}", self.width)
+        match self.signed {
+            true => write!(f, "i{}", self.width),
+            false => write!(f, "u{}", self.width),
+        }
     }
 }
 

--- a/src/typing/typed_ast.rs
+++ b/src/typing/typed_ast.rs
@@ -108,7 +108,7 @@ pub struct TypedComparison {
     pub left: Box<TypedExpr>,
     pub operator: ComparisonOperator,
     pub right: Box<TypedExpr>,
-    pub result_type: Type,
+    pub operand_type: Type,
 }
 
 /// A call expression (the name of the function to call and the arguments to pass).

--- a/src/typing/typed_ast.rs
+++ b/src/typing/typed_ast.rs
@@ -108,6 +108,7 @@ pub struct TypedComparison {
     pub left: Box<TypedExpr>,
     pub operator: ComparisonOperator,
     pub right: Box<TypedExpr>,
+    pub result_type: Type,
 }
 
 /// A call expression (the name of the function to call and the arguments to pass).

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -282,6 +282,8 @@ impl Typer {
             panic!("Expected unsigned integer type '{}', but got negative int_literal '{}'", int_type, int_literal);
         }
 
+        // TODO: Ensure that the int_literal.value fits within the desired width
+
         TypedIntLiteral {
             negative: int_literal.negative,
             int_value: int_literal.value.clone(),

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -275,7 +275,7 @@ impl Typer {
                     int_literal, t
                 )
             }
-            None => IntType { width: 64, signed: false },
+            None => IntType { signed: false, width: 64 },
         };
 
         if int_literal.negative && !int_type.signed {
@@ -447,12 +447,12 @@ mod tests {
                     Statement::VarDeclaration(VarDeclaration {
                         var_name: "a".to_string(),
                         var_value: Expr::IntLiteral(IntLiteral { negative: false, value: "3".to_string() }),
-                        var_type: Type::Int(IntType { width: 64, signed: true }),
+                        var_type: Type::Int(IntType { signed: true, width: 64 }),
                     }),
                     Statement::VarDeclaration(VarDeclaration {
                         var_name: "b".to_string(),
                         var_value: Expr::Identifier("a".to_string()),
-                        var_type: Type::Int(IntType { width: 64, signed: true }),
+                        var_type: Type::Int(IntType { signed: true, width: 64 }),
                     }),
                     Statement::VarDeclaration(VarDeclaration {
                         var_name: "c".to_string(),

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -346,7 +346,7 @@ impl Typer {
             left: Box::new(left),
             operator,
             right: Box::new(right),
-            result_type: left_type, // since both types must be equal
+            operand_type: left_type, // since both types must be equal
         }
     }
 


### PR DESCRIPTION
Add unsigned integers and use the correct LLVM functions for unsigned vs. signed integers, type check the sign of an int and number, improve readability, fix extern linkage, and a few other small additions.