### PR TITLE
Implement --just-compile and --linker-path <PATH>

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,9 +65,9 @@ impl Cli {
         }
     }
 
-    /// Retrieves the provided object output path (returns a default if none provided)
+    /// Retrieves the provided linker path (returns a default if none provided)
     ///
-    /// Note that the default object output path for a file like `test.fl` is `test.o`.
+    /// Note that the default linker path is `gcc`.
     fn get_linker_path(&self) -> PathBuf {
         match &self.linker_path {
             Some(path) => path.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ struct Cli {
 
     /// Whether to just compile without running the linker to generate an executable
     #[arg(long)]
-    just_compile: bool,
+    no_link: bool,
 }
 
 impl Cli {

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ fn main() -> Result<()> {
     let object_output_path = cli.get_object_output_path();
     compiler.to_file(&object_output_path);
 
-    if cli.just_compile {
+    if cli.no_link {
         return Ok(());
     }
 


### PR DESCRIPTION
This PR implements two additional compiler flags that give more flexibility about the linking step. Default behavior is the same, but users can now optionally stop before the linking step using `--just-compile` and specify their linker (default: `gcc`) using `--linker-path`.