### PR TITLE
Add modulo operator

### DIFF
--- a/examples/arithemetic.fl
+++ b/examples/arithemetic.fl
@@ -1,0 +1,7 @@
+fn arithmetic(i32 a) i32 {
+    ret (a +3) /4 * 5 % 3*(-2) -2
+}
+
+pub fn main() i32 {
+    ret arithmetic(5)
+}

--- a/examples/modulo.fl
+++ b/examples/modulo.fl
@@ -1,0 +1,3 @@
+pub fn main() i32 {
+    ret 43 % 2
+}

--- a/grammar.txt
+++ b/grammar.txt
@@ -24,8 +24,8 @@ expr            := logical_or
 logical_or      := {logical_and or} logical_and
 logical_and     := {eq_neq_expr and} eq_neq_expr
 comparison_expr := {add_sub_expr !=,==} add_sub_expr
-add_sub_expr    := {mul_div_expr (+-)} mul_div_expr
-mul_div_expr    := {primary_expr (*/)} primary_expr
+add_sub_expr    := {mul_div_rem_expr (+-)} mul_div_rem_expr
+mul_div_rem_expr    := {primary_expr (*/%)} primary_expr
 primary_expr    := atom | call | '(' expr ')'
                           ^^^^ will become call_and_index_expr
 

--- a/grammar.txt
+++ b/grammar.txt
@@ -20,13 +20,13 @@ body        := '{' [statement]+ '}'
 
 assigment   := IDENTIFIER = expr
 
-expr            := logical_or
-logical_or      := {logical_and or} logical_and
-logical_and     := {eq_neq_expr and} eq_neq_expr
-comparison_expr := {add_sub_expr !=,==} add_sub_expr
-add_sub_expr    := {mul_div_rem_expr (+-)} mul_div_rem_expr
-mul_div_rem_expr    := {primary_expr (*/%)} primary_expr
-primary_expr    := atom | call | '(' expr ')'
+expr             := logical_or
+logical_or       := {logical_and or} logical_and
+logical_and      := {eq_neq_expr and} eq_neq_expr
+comparison_expr  := {add_sub_expr !=,==} add_sub_expr
+add_sub_expr     := {mul_div_rem_expr (+-)} mul_div_rem_expr
+mul_div_rem_expr := {primary_expr (*/%)} primary_expr
+primary_expr     := atom | call | '(' expr ')'
                           ^^^^ will become call_and_index_expr
 
 // call_and_index_expr  := IDENTIFIER { [ '(' [args] ')' ] { '[' [index]  ']' } }

--- a/src/compilation/compiler.rs
+++ b/src/compilation/compiler.rs
@@ -517,6 +517,10 @@ impl Compiler {
                 IntType { signed: true, .. } => LLVMBuildSDiv(self.builder, lhs, rhs, cstr!("sdiv")),
                 IntType { signed: false, .. } => LLVMBuildUDiv(self.builder, lhs, rhs, cstr!("udiv")),
             },
+            Remainder => match int_type {
+                IntType { signed: true, .. } => LLVMBuildSRem(self.builder, lhs, rhs, cstr!("srem")),
+                IntType { signed: false, .. } => LLVMBuildURem(self.builder, lhs, rhs, cstr!("urem")),
+            }
         }
     }
 

--- a/src/lexing/lexer.rs
+++ b/src/lexing/lexer.rs
@@ -286,4 +286,35 @@ mod tests {
 
         assert_eq!(received_tokens, expected_tokens);
     }
+
+    #[test]
+    fn arithmetic() {
+        let source_code = "(a +3) /4 * 5 % 3*(-2) -2";
+        let expected_tokens = vec![
+            Token::LParen,
+            Token::Identifier("a".to_string()),
+            Token::OperatorSymbol(Plus),
+            Token::IntLiteral("3".to_string()),
+            Token::RParen,
+            Token::OperatorSymbol(Slash),
+            Token::IntLiteral("4".to_string()),
+            Token::OperatorSymbol(Asterisk),
+            Token::IntLiteral("5".to_string()),
+            Token::OperatorSymbol(Modulo),
+            Token::IntLiteral("3".to_string()),
+            Token::OperatorSymbol(Asterisk),
+            Token::LParen,
+            Token::OperatorSymbol(Minus),
+            Token::IntLiteral("2".to_string()),
+            Token::RParen,
+            Token::OperatorSymbol(Minus),
+            Token::IntLiteral("2".to_string()),
+        ];
+
+        let source_code_chars: Vec<_> = source_code.chars().collect();
+        let lexer = Lexer::new(&source_code_chars);
+        let received_tokens: Vec<_> = lexer.collect();
+
+        assert_eq!(received_tokens, expected_tokens);
+    }
 }

--- a/src/lexing/lexer.rs
+++ b/src/lexing/lexer.rs
@@ -106,6 +106,7 @@ impl<'a> Lexer<'a> {
 
             ('>', _) => Token::ComparatorSymbol(GreaterThan),
             ('<', _) => Token::ComparatorSymbol(LessThan),
+            ('%', _) => Token::OperatorSymbol(Modulo),
             ('*', _) => Token::OperatorSymbol(Asterisk),
             ('/', _) => Token::OperatorSymbol(Slash),
             ('-', _) => Token::OperatorSymbol(Minus),

--- a/src/lexing/token.rs
+++ b/src/lexing/token.rs
@@ -92,6 +92,7 @@ pub enum OperatorSymbol {
     Minus,
     Asterisk,
     Slash,
+    Modulo,
 }
 
 impl fmt::Display for OperatorSymbol {
@@ -101,6 +102,7 @@ impl fmt::Display for OperatorSymbol {
             Self::Minus => write!(f, "-"),
             Self::Asterisk => write!(f, "*"),
             Self::Slash => write!(f, "/"),
+            Self::Modulo => write!(f, "%"),
         }
     }
 }

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -165,6 +165,7 @@ pub enum BinaryOperator {
     Subtract,
     Multiply,
     Divide,
+    Remainder,
 }
 
 impl fmt::Display for BinaryOperator {
@@ -174,6 +175,7 @@ impl fmt::Display for BinaryOperator {
             Self::Subtract => write!(f, "-"),
             Self::Multiply => write!(f, "*"),
             Self::Divide => write!(f, "/"),
+            Self::Remainder => write!(f, "%"),
         }
     }
 }
@@ -185,6 +187,7 @@ impl From<OperatorSymbol> for BinaryOperator {
             Minus => Self::Subtract,
             Asterisk => Self::Multiply,
             Slash => Self::Divide,
+            Modulo => Self::Remainder,
         }
     }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -920,4 +920,83 @@ mod tests {
 
         assert_eq!(expected, ast);
     }
+
+    #[test]
+    fn arithmetic() {
+        // x=(a+3)/4*5%3*(-2)-2
+        let tokens = vec![
+            Token::Identifier("x".to_string()),
+            Token::AssignmentSymbol(Eq),
+            Token::LParen,
+            Token::Identifier("a".to_string()),
+            Token::OperatorSymbol(Plus),
+            Token::IntLiteral("3".to_string()),
+            Token::RParen,
+            Token::OperatorSymbol(Slash),
+            Token::IntLiteral("4".to_string()),
+            Token::OperatorSymbol(Asterisk),
+            Token::IntLiteral("5".to_string()),
+            Token::OperatorSymbol(Modulo),
+            Token::IntLiteral("3".to_string()),
+            Token::OperatorSymbol(Asterisk),
+            Token::LParen,
+            Token::OperatorSymbol(Minus),
+            Token::IntLiteral("2".to_string()),
+            Token::RParen,
+            Token::OperatorSymbol(Minus),
+            Token::IntLiteral("2".to_string()),
+        ];
+
+        let expected = Some(Statement::Assignment(Assignment {
+            name: "x".to_string(),
+            value: Box::new(Expr::Binary(Binary { 
+                left: Box::new(Expr::Binary(Binary { 
+                    left: Box::new(Expr::Binary(Binary { 
+                        left: Box::new(Expr::Binary(Binary { 
+                            left: Box::new(Expr::Binary(Binary { 
+                                left: Box::new(Expr::Binary(Binary { 
+                                    left: Box::new(Expr::Identifier("a".to_string())), 
+                                    operator: BinaryOperator::Add, 
+                                    right: Box::new(Expr::IntLiteral(IntLiteral { 
+                                        negative: false, 
+                                        value: "3".to_string() 
+                                    })) 
+                                })), 
+                                operator: BinaryOperator::Divide, 
+                                right: Box::new(Expr::IntLiteral(IntLiteral { 
+                                    negative: false, 
+                                    value: "4".to_string() 
+                                })) 
+                            })), 
+                            operator: BinaryOperator::Multiply, 
+                            right: Box::new(Expr::IntLiteral(IntLiteral { 
+                                negative: false, 
+                                value: "5".to_string() 
+                            })) 
+                        })), 
+                        operator: BinaryOperator::Remainder, 
+                        right: Box::new(Expr::IntLiteral(IntLiteral { 
+                            negative: false, 
+                            value: "3".to_string() 
+                        })) 
+                    })), 
+                    operator: BinaryOperator::Multiply, 
+                    right: Box::new(Expr::IntLiteral(IntLiteral { 
+                        negative: true, 
+                        value: "2".to_string() 
+                    }))
+                })), 
+                operator: BinaryOperator::Subtract, 
+                right: Box::new(Expr::IntLiteral(IntLiteral { 
+                    negative: false, 
+                    value: "2".to_string() 
+                }))
+            }))
+        }));
+
+        let mut parser = Parser::new(&tokens);
+        let ast = parser.parse_statement();
+
+        assert_eq!(expected, ast);
+    }
 }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -454,12 +454,12 @@ impl<'a> Parser<'a> {
     /// Parses expressions like `A - B + C`;
     /// see [Parser::parse_expr] for expression-parsing details.
     fn parse_add_sub_expr(&mut self) -> Expr {
-        let mut left_expr_so_far = self.parse_mul_div_expr();
+        let mut left_expr_so_far = self.parse_mul_div_rem_expr();
 
         while let Some(Token::OperatorSymbol(s @ (Plus | Minus))) = self.peek_token(1) {
             let operator = BinaryOperator::from(*s);
             self.skip_token();
-            let right = self.parse_mul_div_expr();
+            let right = self.parse_mul_div_rem_expr();
 
             left_expr_so_far = Expr::Binary(Binary {
                 left: Box::new(left_expr_so_far),
@@ -473,10 +473,10 @@ impl<'a> Parser<'a> {
 
     /// Parses expressions like `A / B * C`;
     /// see [Parser::parse_expr] for expression-parsing details.
-    fn parse_mul_div_expr(&mut self) -> Expr {
+    fn parse_mul_div_rem_expr(&mut self) -> Expr {
         let mut left_expr_so_far = self.parse_primary_expr();
 
-        while let Some(Token::OperatorSymbol(s @ (Asterisk | Slash))) = self.peek_token(1) {
+        while let Some(Token::OperatorSymbol(s @ (Asterisk | Slash | Modulo))) = self.peek_token(1) {
             let operator = BinaryOperator::from(*s);
             self.skip_token();
             let right = self.parse_primary_expr();


### PR DESCRIPTION
Implement the modulo operator (remainder) with same operator precedence as multiplication and division. It is compiled using LLVM signed/unsigned remainder commands.