### PR TITLE
Implement truncation and extension for same-sign integer casts

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -34,6 +34,7 @@
 
 ### Quick Todos
 
+- [ ] Add rustfmt.toml file for fmt and also add warn = ["clippy::unnecessary_mut_passed"] (and other warnings, like docs?)
 - [ ] Implement the '-' unary operator and use it to parse negative literals.
     - [ ] THEN, optionally, type-check to make sure that '-' applied to an unsigned int gets stored in signed int.
 - [ ] Change comparison_expr to separate < <= > >= from == != (which have lower precedence). Update grammar and parsing.

--- a/TODOS.md
+++ b/TODOS.md
@@ -34,6 +34,7 @@
 
 ### Quick Todos
 
+- [ ] Comments at the end of a line???
 - [ ] Add rustfmt.toml file for fmt and also add warn = ["clippy::unnecessary_mut_passed"] (and other warnings, like docs?)
 - [ ] Implement the '-' unary operator and use it to parse negative literals.
     - [ ] THEN, optionally, type-check to make sure that '-' applied to an unsigned int gets stored in signed int.

--- a/TODOS.md
+++ b/TODOS.md
@@ -5,12 +5,12 @@
 - [x] Booleans "bool"
 - [x] Panic if 'main' not defined
 - [x] Allow functions that return something (but not an error type) to be called
-        without that return value getting processed.
+  without that return value getting processed.
 
 
 - [ ] Slightly nicer errors (line number and no word "panic")
 - [ ] Arrays?
-- [ ] Strings (in std library using arrays? rope data struct?)/ pointers? 
+- [ ] Strings (in std library using arrays? rope data struct?)/ pointers?
 - [ ] Deploy the docs and attach link to README.md
 - [ ] Give an overview of how the compiler works in README
 - [ ] Document how to use Flick itself
@@ -34,8 +34,12 @@
 
 ### Quick Todos
 
+- [ ] Implement the '-' unary operator and use it to parse negative literals.
+    - [ ] THEN, optionally, type-check to make sure that '-' applied to an unsigned int gets stored in signed int.
+- [ ] Change comparison_expr to separate < <= > >= from == != (which have lower precedence). Update grammar and parsing.
 - [ ] Edit `hooks/pre-commit-msg` to also _run_ the compiled Flick programs and ensure they exit with 0 exit status
-- [ ] Implement a simple BigInteger function to ensure that the int_value given fits inside the width of the int type provided in typer
+- [ ] Implement a simple BigInteger function to ensure that the int_value given fits inside the width of the int type
+  provided in typer
 - [ ] Make `Typer` take the program in its `new()`
 - [ ] Make all module and crate level docstrings start with `//!` instead of `///` and
 - [ ] Move `types.rs` into `typing` module and fix the ignored example in `typing/mod.rs` docstring
@@ -76,3 +80,7 @@
 
 - [ ] Write a syntax highlighting extension for code editors
 - [ ] Support importing other flick source files (by compiling multiple programs in LLVM)
+
+## Documentation todos
+
+- [ ] Document how casting works

--- a/examples/extend.fl
+++ b/examples/extend.fl
@@ -1,0 +1,5 @@
+pub fn main() u8 {
+    u2 smaller = 1
+    u4 bigger = 3 + (u4) smaller
+    ret (u8) bigger
+}

--- a/examples/printnum.fl
+++ b/examples/printnum.fl
@@ -1,0 +1,24 @@
+
+
+extern fn putchar(u8 c) u8
+
+pub fn printnum(u64 n) {
+    u64 reversed = 0
+    while n > 0 {
+        reversed *= 10
+        reversed += n % 10
+        n /= 10
+    }
+    while reversed > 0 {
+        u8 digit = (u8) (reversed % 10)
+        u8 _ = putchar(48 + digit)
+        reversed /= 10
+    }
+}
+
+pub fn main() u8 {
+    printnum(2468)
+    // newline
+    putchar(10) 
+    ret 0
+}

--- a/examples/printnum.fl
+++ b/examples/printnum.fl
@@ -1,5 +1,3 @@
-
-
 extern fn putchar(u8 c) u8
 
 pub fn printnum(u64 n) {

--- a/examples/zero_extend.fl
+++ b/examples/zero_extend.fl
@@ -1,5 +1,5 @@
 pub fn main() u8 {
     u2 smaller = 1
     u4 bigger = 3 + (u4) smaller
-    ret (u8) bigger
+    ret (u8) (u6) (u4) bigger
 }

--- a/grammar.txt
+++ b/grammar.txt
@@ -25,9 +25,13 @@ logical_or       := {logical_and or} logical_and
 logical_and      := {eq_neq_expr and} eq_neq_expr
 comparison_expr  := {add_sub_expr !=,==} add_sub_expr
 add_sub_expr     := {mul_div_rem_expr (+-)} mul_div_rem_expr
-mul_div_rem_expr := {primary_expr (*/%)} primary_expr
+mul_div_rem_expr := {unary_expr (*/%)} unary_expr
+unary_expr       := unary_op unary_expr | primary_expr
 primary_expr     := atom | call | '(' expr ')'
-                          ^^^^ will become call_and_index_expr
+                           ^^^^ will become call_and_index_expr
+
+unary_op     := cast          # In the future, this will include things like !
+cast         := '(' VARTYPE ')'
 
 // call_and_index_expr  := IDENTIFIER { [ '(' [args] ')' ] { '[' [index]  ']' } }
 call        := IDENTIFIER [ '(' [args] ')' ]

--- a/grammar.txt
+++ b/grammar.txt
@@ -30,8 +30,7 @@ unary_expr       := unary_op unary_expr | primary_expr
 primary_expr     := atom | call | '(' expr ')'
                            ^^^^ will become call_and_index_expr
 
-unary_op     := cast          # In the future, this will include things like !
-cast         := '(' VARTYPE ')'
+unary_op     :=  '(' VARTYPE ')'   # In the future, we will add | '-' | '!', etc.
 
 // call_and_index_expr  := IDENTIFIER { [ '(' [args] ')' ] { '[' [index]  ']' } }
 call        := IDENTIFIER [ '(' [args] ')' ]

--- a/src/compilation/compiler.rs
+++ b/src/compilation/compiler.rs
@@ -454,6 +454,7 @@ impl Compiler {
             TypedExpr::Binary(bin_expr) => self.compile_bin_expr(bin_expr),
             TypedExpr::Comparison(comparison) => self.compile_comparison_expr(comparison),
             TypedExpr::Call(call) => self.compile_call(call),
+            TypedExpr::Unary(_) => todo!(),
         }
     }
 

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -7,7 +7,7 @@ use std::fmt;
 /// A program consisting of at least one [GlobalStatement].
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Program {
-    pub global_statements: Vec<GlobalStatement>
+    pub global_statements: Vec<GlobalStatement>,
 }
 
 /// A global statement is something that can be written in the "global" scope, as opposed
@@ -43,16 +43,19 @@ impl fmt::Display for FuncProto {
             .map(|p| format!("{} {}", p.param_type, p.param_name))
             .collect::<Vec<String>>()
             .join(", ");
-        write!(f, "{} {}({}) {}", self.func_visibility, self.name, params, self.return_type)
+        write!(
+            f,
+            "{} {}({}) {}",
+            self.func_visibility, self.name, params, self.return_type
+        )
     }
 }
-
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum FuncVisibility {
     Public,
     Private,
-    Extern
+    Extern,
 }
 
 impl fmt::Display for FuncVisibility {
@@ -60,7 +63,7 @@ impl fmt::Display for FuncVisibility {
         match self {
             Self::Public => write!(f, "pub fn"),
             Self::Private => write!(f, "fn"),
-            Self::Extern => write!(f, "extern fn")
+            Self::Extern => write!(f, "extern fn"),
         }
     }
 }
@@ -99,11 +102,10 @@ pub enum Statement {
     If(If),
 }
 
-/// A variable declaration and, optionally, variable definition as well.
+/// A variable declaration.
 ///
 /// This struct stores the name and type of the declared variable, as well as its
-/// value (if the variable declaration comes with an assignment, like `int a = 7;` instead of
-/// `int a;`).
+/// initial value.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct VarDeclaration {
     pub var_name: String,
@@ -111,8 +113,8 @@ pub struct VarDeclaration {
     pub var_value: Expr,
 }
 
-/// A if statement.
-/// 
+/// An if statement.
+///
 /// Note, `then_body` corresponds to the statements to be executed if the condition is true,
 /// and `else_body` (optional) corresponds to the "else" block of the if statement.
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -121,7 +123,6 @@ pub struct If {
     pub then_body: Vec<Statement>,
     pub else_body: Option<Vec<Statement>>,
 }
-
 
 /// A while loop (its 'while condition' and its body).
 #[derive(Debug, PartialEq, Eq, Clone)]

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -280,7 +280,7 @@ pub struct Call {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Unary {
     pub operator: UnaryOperator,
-    pub expr: Box<Expr>,
+    pub operand: Box<Expr>,
 }
 
 /// A unary operator, like "cast to u32" or "not".

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -142,6 +142,7 @@ pub enum Expr {
     Binary(Binary),
     Comparison(Comparison),
     Call(Call),
+    Unary(Unary),
 }
 
 /// An assignment statement (the variable name and the new value).
@@ -273,4 +274,18 @@ impl From<ComparatorSymbol> for ComparisonOperator {
 pub struct Call {
     pub function_name: String,
     pub args: Vec<Expr>,
+}
+
+/// A unary expression, which consists of an operator (e.g. "cast to u32") and a value.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Unary {
+    pub operator: UnaryOperator,
+    pub expr: Box<Expr>,
+}
+
+/// A unary operator, like "cast to u32" or "not".
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum UnaryOperator {
+    /// A cast converts its operand into the specified destination [Type].
+    Cast(Type),
 }

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -43,11 +43,7 @@ impl fmt::Display for FuncProto {
             .map(|p| format!("{} {}", p.param_type, p.param_name))
             .collect::<Vec<String>>()
             .join(", ");
-        write!(
-            f,
-            "{} {}({}) {}",
-            self.func_visibility, self.name, params, self.return_type
-        )
+        write!(f, "{} {}({}) {}", self.func_visibility, self.name, params, self.return_type)
     }
 }
 

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -1039,10 +1039,7 @@ mod tests {
     fn unary_cast_of_call() {
         let tokens = vec![
             Token::LParen,
-            Token::Type(Type::Int(IntType {
-                signed: true,
-                width: 64,
-            })),
+            Token::Type(Type::Int(IntType { width: 64, signed: true })),
             Token::RParen,
             Token::Identifier("foo".to_string()),
             Token::LParen,
@@ -1051,10 +1048,7 @@ mod tests {
         ];
 
         let expected = Expr::Unary(Unary {
-            operator: UnaryOperator::Cast(Type::Int(IntType {
-                signed: true,
-                width: 64,
-            })),
+            operator: UnaryOperator::Cast(Type::Int(IntType { width: 64, signed: true })),
             operand: Box::new(Expr::Call(Call {
                 function_name: "foo".to_string(),
                 args: vec![Expr::IntLiteral(IntLiteral {

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -506,7 +506,7 @@ impl<'a> Parser<'a> {
         self.assert_next_token(Token::LParen);
         let cast_type = self.parse_type();
         self.assert_next_token(Token::RParen);
-        let operand = self.parse_primary_expr();
+        let operand = self.parse_unary_expr();
 
         Unary {
             operator: UnaryOperator::Cast(cast_type),

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -506,11 +506,11 @@ impl<'a> Parser<'a> {
         self.assert_next_token(Token::LParen);
         let cast_type = self.parse_type();
         self.assert_next_token(Token::RParen);
-        let expr = self.parse_primary_expr();
+        let operand = self.parse_primary_expr();
 
         Unary {
             operator: UnaryOperator::Cast(cast_type),
-            expr: Box::new(expr),
+            operand: Box::new(operand),
         }
     }
 
@@ -1055,7 +1055,7 @@ mod tests {
                 signed: true,
                 width: 64,
             })),
-            expr: Box::new(Expr::Call(Call {
+            operand: Box::new(Expr::Call(Call {
                 function_name: "foo".to_string(),
                 args: vec![Expr::IntLiteral(IntLiteral {
                     negative: false,

--- a/src/typing/typed_ast.rs
+++ b/src/typing/typed_ast.rs
@@ -1,4 +1,4 @@
-use crate::ast::{BinaryOperator, ComparisonOperator, FuncProto};
+use crate::ast::{BinaryOperator, ComparisonOperator, FuncProto, UnaryOperator};
 use crate::types::IntType;
 use crate::Type;
 
@@ -72,6 +72,7 @@ pub enum TypedExpr {
     Binary(TypedBinary),
     Comparison(TypedComparison),
     Call(TypedCall),
+    Unary(TypedUnary),
 }
 
 /// A typed version of [Assignment](crate::ast::Assignment).
@@ -127,4 +128,13 @@ pub struct TypedCall {
 pub struct TypedIdentifier {
     pub name: String,
     pub id_type: Type,
+}
+
+
+/// A typed version of [Unary](crate::ast::Unary).
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct TypedUnary {
+    pub operator: UnaryOperator,
+    pub operand: Box<TypedExpr>,
+    pub result_type: Type,
 }

--- a/src/typing/typed_ast.rs
+++ b/src/typing/typed_ast.rs
@@ -75,6 +75,21 @@ pub enum TypedExpr {
     Unary(TypedUnary),
 }
 
+impl TypedExpr {
+    /// Extracts the type of this typed expression
+    pub fn get_type(&self) -> Type {
+        match self {
+            Self::Identifier(id) => id.id_type.clone(),
+            Self::IntLiteral(int) => Type::Int(int.int_type),
+            Self::BoolLiteral(_) => Type::Bool,
+            Self::Binary(binary) => binary.result_type.clone(),
+            Self::Comparison(_) => Type::Bool,
+            Self::Call(call) => Type::Func(call.function_proto.clone()),
+            Self::Unary(unary) => unary.result_type.clone(),
+        }
+    }
+}
+
 /// A typed version of [Assignment](crate::ast::Assignment).
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypedAssignment {

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -281,7 +281,7 @@ impl Typer {
         };
 
         let typed_operand = self.type_expr(&unary.operand, desired_operand_type);
-        let operand_type = self.find_type(&typed_operand);
+        let operand_type = typed_operand.get_type();
 
         // Now that we know the type of the operand, we can check if the unary operator is valid
         match &unary.operator {
@@ -357,8 +357,8 @@ impl Typer {
         let operator = binary_expr.operator;
         let right = self.type_expr(&binary_expr.right, desired_type);
 
-        let left_type = self.find_type(&left);
-        let right_type = self.find_type(&right);
+        let left_type = left.get_type();
+        let right_type = right.get_type();
         if left_type != right_type {
             panic!(
                 "Operator '{}' needs left-hand-side ({}) and right-hand-side ({}) to be the same type",
@@ -397,8 +397,8 @@ impl Typer {
         let operator = comparison.operator;
         let right = self.type_expr(&comparison.right, None);
 
-        let left_type = self.find_type(&left);
-        let right_type = self.find_type(&right);
+        let left_type = left.get_type();
+        let right_type = right.get_type();
 
         if left_type != right_type {
             panic!(
@@ -464,19 +464,6 @@ impl Typer {
         }
     }
 
-    /// Extracts the type from a typed expression.
-    fn find_type(&mut self, typed_expr: &TypedExpr) -> Type {
-        match typed_expr {
-            TypedExpr::Identifier(id) => id.id_type.clone(),
-            TypedExpr::IntLiteral(int) => Type::Int(int.int_type),
-            TypedExpr::BoolLiteral(_) => Type::Bool,
-            TypedExpr::Binary(binary) => binary.result_type.clone(),
-            TypedExpr::Comparison(_) => Type::Bool,
-            TypedExpr::Call(call) => Type::Func(call.function_proto.clone()),
-            TypedExpr::Unary(unary) => unary.result_type.clone(),
-        }
-    }
-    
     /// Panics if the cast is invalid, like casting from an unsigned type to a signed type.
     fn check_valid_cast(cast_type: &Type, operand_type: &Type) {
         match (cast_type, operand_type) {

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -232,7 +232,6 @@ impl Typer {
         ret.map(|e| self.type_expr(e, Some(function_return_type)))
     }
 
-    // desired type is optional because, for example, 17 doesn't have a desired type
     /// Recursively type-checks the provided expression, confirming that it is of type
     /// `desired_type`.
     ///
@@ -247,7 +246,7 @@ impl Typer {
                 TypedExpr::IntLiteral(self.type_int_literal(int, desired_type))
             }
             Expr::BoolLiteral(b) => TypedExpr::BoolLiteral(*b),
-            Expr::Binary(b) => TypedExpr::Binary(self.type_bin_expr(b, desired_type)),
+            Expr::Binary(b) => TypedExpr::Binary(self.type_binary_expr(b, desired_type)),
             Expr::Comparison(c) => {
                 TypedExpr::Comparison(self.type_comparison_expr(c, desired_type))
             }
@@ -308,10 +307,10 @@ impl Typer {
     }
 
     /// Types a binary expression; see [Typer::type_expr] for details.
-    fn type_bin_expr(&mut self, bin_expr: &Binary, desired_type: Option<&Type>) -> TypedBinary {
-        let left = self.type_expr(&bin_expr.left, desired_type);
-        let operator = bin_expr.operator;
-        let right = self.type_expr(&bin_expr.right, desired_type);
+    fn type_binary_expr(&mut self, binary_expr: &Binary, desired_type: Option<&Type>) -> TypedBinary {
+        let left = self.type_expr(&binary_expr.left, desired_type);
+        let operator = binary_expr.operator;
+        let right = self.type_expr(&binary_expr.right, desired_type);
 
         let left_type = self.find_type(&left);
         let right_type = self.find_type(&right);

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -1,11 +1,12 @@
 use crate::ast::{
-    Assignment, Binary, Call, Comparison, Expr, FuncDef, FuncProto, GlobalStatement, If, IntLiteral, Program, Statement, VarDeclaration, WhileLoop, FuncVisibility
+    Assignment, Binary, Call, Comparison, Expr, FuncDef, FuncProto, FuncVisibility,
+    GlobalStatement, If, IntLiteral, Program, Statement, VarDeclaration, WhileLoop,
 };
 use crate::scope_manager::ScopeManager;
 use crate::typed_ast::{
     TypedAssignment, TypedBinary, TypedCall, TypedComparison, TypedExpr, TypedFuncDef,
-    TypedIdentifier, TypedIf, TypedIntLiteral, TypedProgram, TypedStatement, TypedVarDeclaration,
-    TypedWhileLoop, TypedGlobalStatement
+    TypedGlobalStatement, TypedIdentifier, TypedIf, TypedIntLiteral, TypedProgram, TypedStatement,
+    TypedVarDeclaration, TypedWhileLoop,
 };
 use crate::types::IntType;
 use crate::Type;
@@ -62,8 +63,8 @@ impl Typer {
         if func_proto.func_visibility != FuncVisibility::Public {
             panic!("The 'main' function should be public");
         }
-        
-        if func_proto.params.len() > 0 {
+
+        if !func_proto.params.is_empty() {
             panic!("The 'main' function should not accept any parameters");
         }
 
@@ -251,6 +252,7 @@ impl Typer {
                 TypedExpr::Comparison(self.type_comparison_expr(c, desired_type))
             }
             Expr::Call(c) => TypedExpr::Call(self.type_call(c, desired_type)),
+            Expr::Unary(_) => todo!(),
         }
     }
 

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -661,36 +661,21 @@ mod tests {
                         var_value: TypedExpr::IntLiteral(TypedIntLiteral {
                             negative: false,
                             int_value: "3".to_string(),
-                            int_type: IntType {
-                                width: 8,
-                                signed: false,
-                            },
+                            int_type: IntType { width: 8, signed: false },
                         }),
-                        var_type: Type::Int(IntType {
-                            width: 8,
-                            signed: false,
-                        }),
+                        var_type: Type::Int(IntType { width: 8, signed: false }),
                     }),
                     TypedStatement::VarDeclaration(TypedVarDeclaration {
                         var_name: "b".to_string(),
-                        var_type: Type::Int(IntType {
-                            width: 8,
-                            signed: false,
-                        }),
+                        var_type: Type::Int(IntType { width: 8, signed: false }),
                         var_value: TypedExpr::Identifier(TypedIdentifier {
                             name: "a".to_string(),
-                            id_type: Type::Int(IntType {
-                                width: 8,
-                                signed: false,
-                            }),
+                            id_type: Type::Int(IntType { width: 8, signed: false }),
                         }),
                     }),
                     TypedStatement::Return(Some(TypedExpr::Identifier(TypedIdentifier {
                         name: "b".to_string(),
-                        id_type: Type::Int(IntType {
-                            width: 8,
-                            signed: false,
-                        }),
+                        id_type: Type::Int(IntType { width: 8, signed: false }),
                     }))),
                 ],
             })],
@@ -715,10 +700,7 @@ mod tests {
                     func_visibility: FuncVisibility::Public,
                     name: "main".to_string(),
                     params: vec![],
-                    return_type: Box::new(Type::Int(IntType {
-                        width: 8,
-                        signed: false,
-                    })),
+                    return_type: Box::new(Type::Int(IntType { width: 8, signed: false })),
                 },
                 body: vec![
                     Statement::VarDeclaration(VarDeclaration {
@@ -727,16 +709,10 @@ mod tests {
                             negative: false,
                             value: "3".to_string(),
                         }),
-                        var_type: Type::Int(IntType {
-                            width: 32,
-                            signed: true,
-                        }),
+                        var_type: Type::Int(IntType { width: 32, signed: true }),
                     }),
                     Statement::Return(Some(Expr::Unary(Unary {
-                        operator: UnaryOperator::Cast(Type::Int(IntType {
-                            width: 8,
-                            signed: false,
-                        })),
+                        operator: UnaryOperator::Cast(Type::Int(IntType { width: 8, signed: false })),
                         operand: Box::new(Expr::Identifier("a".to_string())),
                     }))),
                 ],
@@ -760,10 +736,7 @@ mod tests {
                     func_visibility: FuncVisibility::Public,
                     name: "main".to_string(),
                     params: vec![],
-                    return_type: Box::new(Type::Int(IntType {
-                        width: 8,
-                        signed: false,
-                    })),
+                    return_type: Box::new(Type::Int(IntType { width: 8, signed: false })),
                 },
                 body: vec![
                     Statement::VarDeclaration(VarDeclaration {
@@ -772,16 +745,10 @@ mod tests {
                             negative: false,
                             value: "3".to_string(),
                         }),
-                        var_type: Type::Int(IntType {
-                            width: 32,
-                            signed: false,
-                        }),
+                        var_type: Type::Int(IntType { width: 32, signed: false }),
                     }),
                     Statement::Return(Some(Expr::Unary(Unary {
-                        operator: UnaryOperator::Cast(Type::Int(IntType {
-                            width: 8,
-                            signed: false,
-                        })),
+                        operator: UnaryOperator::Cast(Type::Int(IntType { width: 8, signed: false })),
                         operand: Box::new(Expr::Identifier("a".to_string())),
                     }))),
                 ],
@@ -794,10 +761,7 @@ mod tests {
                     func_visibility: FuncVisibility::Public,
                     name: "main".to_string(),
                     params: vec![],
-                    return_type: Box::new(Type::Int(IntType {
-                        width: 8,
-                        signed: false,
-                    })),
+                    return_type: Box::new(Type::Int(IntType { width: 8, signed: false })),
                 },
                 body: vec![
                     TypedStatement::VarDeclaration(TypedVarDeclaration {
@@ -805,32 +769,17 @@ mod tests {
                         var_value: TypedExpr::IntLiteral(TypedIntLiteral {
                             negative: false,
                             int_value: "3".to_string(),
-                            int_type: IntType {
-                                width: 32,
-                                signed: false,
-                            },
+                            int_type: IntType { width: 32, signed: false },
                         }),
-                        var_type: Type::Int(IntType {
-                            width: 32,
-                            signed: false,
-                        }),
+                        var_type: Type::Int(IntType { width: 32, signed: false }),
                     }),
                     TypedStatement::Return(Some(TypedExpr::Unary(TypedUnary {
-                        operator: UnaryOperator::Cast(Type::Int(IntType {
-                            width: 8,
-                            signed: false,
-                        })),
+                        operator: UnaryOperator::Cast(Type::Int(IntType { width: 8, signed: false })),
                         operand: Box::new(TypedExpr::Identifier(TypedIdentifier {
                             name: "a".to_string(),
-                            id_type: Type::Int(IntType {
-                                width: 32,
-                                signed: false,
-                            }),
+                            id_type: Type::Int(IntType { width: 32, signed: false }),
                         })),
-                        result_type: Type::Int(IntType {
-                            width: 8,
-                            signed: false,
-                        }),
+                        result_type: Type::Int(IntType { width: 8, signed: false }),
                     }))),
                 ],
             })],


### PR DESCRIPTION
This PR introduces integer truncation and extension, allowing casts like `(i32) x`.

> [!NOTE]
> Only `signed -> signed` and `unsigned -> unsigned` casts are supported for now. 

Summary of changes:
- Add the `Unary` expression
- Parse casts of the form `(VARTYPE) expr` as unary expressions
- Type-check casts to block all casts except integer casts of the same sign
- Compile casts as `Truncate`, `Zero-extend`, or `Sign-extend` instructions
