### PR TITLE
Allow inline comments

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -34,7 +34,7 @@
 
 ### Quick Todos
 
-- [ ] Comments at the end of a line???
+- [x] Comments at the end of a line???
 - [ ] Add rustfmt.toml file for fmt and also add warn = ["clippy::unnecessary_mut_passed"] (and other warnings, like docs?)
 - [ ] Implement the '-' unary operator and use it to parse negative literals.
     - [ ] THEN, optionally, type-check to make sure that '-' applied to an unsigned int gets stored in signed int.

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,6 +1,6 @@
 ## Roadmap to working web demo!!!
 
-- [ ] Manually casting types?
+- [x] Manually casting types?
 - [ ] And/or?
 - [x] Booleans "bool"
 - [x] Panic if 'main' not defined

--- a/examples/inline_comments.fl
+++ b/examples/inline_comments.fl
@@ -1,0 +1,3 @@
+pub fn main() u8 {
+    ret 2 // This is an inline comment
+}

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -60,7 +60,8 @@ impl<'a> Parser<'a> {
     fn parse_global_statement(&mut self) -> Option<GlobalStatement> {
         match self.peek_token(1) {
             Some(Token::Extern) => Some(GlobalStatement::Extern(self.parse_func_proto())),
-            Some(_) => Some(GlobalStatement::FuncDef(self.parse_func_def())),
+            Some(Token::Fn | Token::Pub) => Some(GlobalStatement::FuncDef(self.parse_func_def())),
+            Some(t) => panic!("Unknown global statement starting with token '{}'", t),
             None => None,
         }
     }
@@ -69,9 +70,7 @@ impl<'a> Parser<'a> {
     fn skip_newlines_comments_and_docstrings(&mut self) {
         // todo take into account the fact that docstring CAN appear in parse tree
         // enjoy this beautiful formatting <3
-        while let Some(Token::Newline | Token::Comment(_) | Token::Docstring(_)) =
-            self.peek_token(1)
-        {
+        while let Some(Token::Newline | Token::Comment(_) | Token::Docstring(_)) = self.peek_token(1) {
             self.skip_token();
         }
     }
@@ -205,7 +204,7 @@ impl<'a> Parser<'a> {
         };
 
         match self.next_token() {
-            Some(Token::Newline) | None => Some(statement),
+            Some(Token::Newline | Token::Comment(_) | Token::Docstring(_)) | None => Some(statement),
             Some(token) => panic!("Expected newline or EOF but received {}", token),
         }
     }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -69,7 +69,6 @@ impl<'a> Parser<'a> {
     /// Advances the cursor past all newline, comment, and docstring tokens.
     fn skip_newlines_comments_and_docstrings(&mut self) {
         // todo take into account the fact that docstring CAN appear in parse tree
-        // enjoy this beautiful formatting <3
         while let Some(Token::Newline | Token::Comment(_) | Token::Docstring(_)) = self.peek_token(1) {
             self.skip_token();
         }


### PR DESCRIPTION
Previously, code like this would throw an error:

```
pub fn main() u8 {
    ret 2 // This is an inline comment
}
```

In fact, no inline comment would work. This was because our parse_statement code only expected a newline to end the statement (but in reality, a newline, comment, or docstring can end a statement). So I added support for comments ending a statement. Now the above code compiles.