### PR TITLE
Negative as unary operator

### DIFF
--- a/examples/negate.fl
+++ b/examples/negate.fl
@@ -1,7 +1,7 @@
 pub fn main() u8 {
     i8 a = 2
     i8 b = -a
-    if (i64) b == -2 {
+    if b == (i8) -2 {
         ret 0
     }
     ret 1

--- a/examples/negate.fl
+++ b/examples/negate.fl
@@ -1,8 +1,7 @@
 pub fn main() u8 {
     i8 a = 2
     i8 b = -a
-    i8 expected = -2
-    if b == expected {
+    if (i64) b == -2 {
         ret 0
     }
     ret 1

--- a/examples/negate.fl
+++ b/examples/negate.fl
@@ -1,0 +1,9 @@
+pub fn main() u8 {
+    i8 a = 2
+    i8 b = -a
+    i8 expected = -2
+    if b == expected {
+        ret 0
+    }
+    ret 1
+}

--- a/examples/negative_numbers.fl
+++ b/examples/negative_numbers.fl
@@ -1,8 +1,8 @@
 pub fn main() u8 {
     i8 a = -1
     i8 b = 5 -2 - a
-    i8 limit = 0
-    if b < limit {
+    i8 limit = 4
+    if b == limit {
         ret 0
     }
     ret 1

--- a/src/compilation/compiler.rs
+++ b/src/compilation/compiler.rs
@@ -556,7 +556,7 @@ impl Compiler {
     /// Compiles a negation expression.
     unsafe fn compile_negation(&mut self, operand: LLVMValueRef, source_type: &Type) -> LLVMValueRef {
         match source_type {
-            Type::Int(_) => LLVMBuildNeg(self.builder, operand, cstr!("neg")),
+            Type::Int(IntType { signed: true, .. }) => LLVMBuildNeg(self.builder, operand, cstr!("neg")),
             _ => panic!("Unsupported type for negation, can only handle integers; this should have been handled by typer"),
         }
     }

--- a/src/parsing/ast.rs
+++ b/src/parsing/ast.rs
@@ -133,7 +133,7 @@ pub struct WhileLoop {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Expr {
     Identifier(String),
-    IntLiteral(IntLiteral),
+    IntLiteral(String),
     BoolLiteral(bool),
     Binary(Binary),
     Comparison(Comparison),
@@ -146,24 +146,6 @@ pub enum Expr {
 pub struct Assignment {
     pub name: String,
     pub value: Box<Expr>,
-}
-
-/// An integer literal, which represents a constant integer value in the source code.
-///
-/// For example, `42` or `-42` are integer literals.
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub struct IntLiteral {
-    pub negative: bool,
-    pub value: String,
-}
-
-impl fmt::Display for IntLiteral {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.negative {
-            write!(f, "-")?;
-        }
-        write!(f, "{}", self.value)
-    }
 }
 
 /// A binary expression (the operator and the left/right-hand sides).
@@ -284,4 +266,6 @@ pub struct Unary {
 pub enum UnaryOperator {
     /// A cast converts its operand into the specified destination [Type].
     Cast(Type),
+    /// Logical negation.
+    Negate
 }

--- a/src/parsing/mod.rs
+++ b/src/parsing/mod.rs
@@ -12,13 +12,13 @@
 /// # let _ =
 /// Expr::Binary(
 ///     Binary {
-///         left: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "9".to_string() })),
+///         left: Box::new(Expr::IntLiteral("9".to_string())),
 ///         operator: BinaryOperator::Multiply,
 ///         right: Box::new(Expr::Binary(
 ///             Binary {
-///                 left: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "2".to_string() })),
+///                 left: Box::new(Expr::IntLiteral("2".to_string())),
 ///                 operator: BinaryOperator::Add,
-///                 right: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "3".to_string() })),
+///                 right: Box::new(Expr::IntLiteral("3".to_string())),
 ///             }
 ///         )),
 ///     }

--- a/src/parsing/parser.rs
+++ b/src/parsing/parser.rs
@@ -494,9 +494,20 @@ impl<'a> Parser<'a> {
     /// Parses expressions like `-A` or `(u32) B`
     fn parse_unary_expr(&mut self) -> Expr {
         match (self.peek_token(1), self.peek_token(2)) {
-            // (Some(Token::OperatorSymbol(Minus)), _) => todo!("parse unary minus"),
+            (Some(Token::OperatorSymbol(Minus)), _) => Expr::Unary(self.parse_negation()),
             (Some(Token::LParen), Some(Token::Type(_))) => Expr::Unary(self.parse_cast()),
             _ => self.parse_primary_expr(),
+        }
+    }
+
+    /// Parses negation expressions like `-A`.
+    fn parse_negation(&mut self) -> Unary {
+        self.assert_next_token(Token::OperatorSymbol(Minus));
+        let operand = self.parse_unary_expr();
+
+        Unary {
+            operator: UnaryOperator::Negate,
+            operand: Box::new(operand),
         }
     }
 
@@ -582,10 +593,7 @@ impl<'a> Parser<'a> {
     fn parse_atom(&mut self) -> Expr {
         match (self.peek_token(1), self.peek_token(2)) {
             (Some(Token::Identifier(_)), _) => Expr::Identifier(self.parse_identifier()),
-
             (Some(Token::IntLiteral(_)), _) => Expr::IntLiteral(self.parse_int_literal()),
-            (Some(Token::OperatorSymbol(Minus)), Some(Token::IntLiteral(_))) => Expr::IntLiteral(self.parse_int_literal()),
-
             (Some(Token::True | Token::False), _) => Expr::BoolLiteral(self.parse_bool_literal()),
 
             // todo Some(Token::StrLiteral())
@@ -600,21 +608,10 @@ impl<'a> Parser<'a> {
     /// # Flick example code
     /// - `42`
     /// - `-42`
-    fn parse_int_literal(&mut self) -> IntLiteral {
-        let mut negative = false;
-
-        // Check if the next token is a minus sign.
-        if let Some(Token::OperatorSymbol(Minus)) = self.peek_token(1) {
-            negative = true;
-            self.skip_token(); // Skip the minus sign
-        }
-
+    fn parse_int_literal(&mut self) -> String {
         // The next token should be an integer literal.
         match self.next_token() {
-            Some(Token::IntLiteral(n)) => IntLiteral {
-                negative,
-                value: n.clone(), // Use the value from the token
-            },
+            Some(Token::IntLiteral(n)) => n.clone(),
             _ => unreachable!("This function is called from parse_atom, which already checks the next token")
         }
     }
@@ -646,7 +643,7 @@ mod tests {
         let expected = Some(Statement::VarDeclaration(VarDeclaration {
             var_name: "x".to_string(),
             var_type: Type::Int(IntType { signed: true, width: 64 }),
-            var_value: Expr::IntLiteral(IntLiteral { negative: false, value: "5".to_string() }),
+            var_value: Expr::IntLiteral("5".to_string()),
         }));
 
         let mut parser = Parser::new(&tokens);
@@ -664,7 +661,7 @@ mod tests {
         ];
         let expected = Some(Statement::Assignment(Assignment {
             name: "num".to_string(),
-            value: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "10".to_string() })),
+            value: Box::new(Expr::IntLiteral("10".to_string())),
         }));
 
         let mut parser = Parser::new(&tokens);
@@ -716,23 +713,23 @@ mod tests {
         let expected = Expr::Binary(Binary {
             left: Box::new(Expr::Binary(Binary {
                 left: Box::new(Expr::Binary(Binary {
-                    left: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "10".to_string() })),
+                    left: Box::new(Expr::IntLiteral("10".to_string())),
                     operator: BinaryOperator::Add,
                     right: Box::new(Expr::Binary(Binary {
                         left: Box::new(Expr::Binary(Binary {
-                            left: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "3".to_string() })),
+                            left: Box::new(Expr::IntLiteral("3".to_string())),
                             operator: BinaryOperator::Multiply,
-                            right: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "8".to_string() })),
+                            right: Box::new(Expr::IntLiteral("8".to_string())),
                         })),
                         operator: BinaryOperator::Divide,
-                        right: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "4".to_string() })),
+                        right: Box::new(Expr::IntLiteral("4".to_string())),
                     })),
                 })),
                 operator: BinaryOperator::Subtract,
-                right: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "13".to_string() })),
+                right: Box::new(Expr::IntLiteral("13".to_string())),
             })),
             operator: BinaryOperator::Add,
-            right: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "5".to_string() })),
+            right: Box::new(Expr::IntLiteral("5".to_string())),
         });
 
         let mut parser = Parser::new(&tokens);
@@ -753,12 +750,12 @@ mod tests {
             Token::RParen,
         ];
         let expected = Expr::Binary(Binary {
-            left: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "9".to_string() })),
+            left: Box::new(Expr::IntLiteral("9".to_string())),
             operator: BinaryOperator::Multiply,
             right: Box::new(Expr::Binary(Binary {
-                left: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "2".to_string() })),
+                left: Box::new(Expr::IntLiteral("2".to_string())),
                 operator: BinaryOperator::Add,
-                right: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "3".to_string() })),
+                right: Box::new(Expr::IntLiteral("3".to_string())),
             })),
         });
 
@@ -784,7 +781,7 @@ mod tests {
         ];
         let expected = vec![Statement::Assignment(Assignment {
             name: "a".to_string(),
-            value: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "2".to_string() })),
+            value: Box::new(Expr::IntLiteral("2".to_string())),
         })];
 
         let mut parser = Parser::new(&tokens);
@@ -813,10 +810,10 @@ mod tests {
             args: vec![
                 Expr::Call(Call {
                     function_name: "f".to_string(),
-                    args: vec![Expr::IntLiteral(IntLiteral { negative: false, value: "1".to_string() })],
+                    args: vec![Expr::IntLiteral("1".to_string())],
                 }),
-                Expr::IntLiteral(IntLiteral { negative: false, value: "10".to_string() }),
-                Expr::IntLiteral(IntLiteral { negative: false, value: "20".to_string() }),
+                Expr::IntLiteral("10".to_string()),
+                Expr::IntLiteral("20".to_string()),
             ],
         });
 
@@ -891,7 +888,7 @@ mod tests {
             condition: Expr::Comparison(Comparison { 
                 left: Box::new(Expr::Identifier("x".to_string())), 
                 operator: ComparisonOperator::LessOrEqualTo, 
-                right: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "5".to_string() })) ,
+                right: Box::new(Expr::IntLiteral("5".to_string())) ,
             }), 
             then_body: vec![Statement::Return(None)], 
             else_body: Some(vec![
@@ -899,7 +896,7 @@ mod tests {
                     condition: Expr::Comparison(Comparison { 
                         left: Box::new(Expr::Identifier("x".to_string())), 
                         operator: ComparisonOperator::LessOrEqualTo, 
-                        right: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "10".to_string() })) ,
+                        right: Box::new(Expr::IntLiteral("10".to_string())) ,
                     }),
                     then_body: vec![Statement::Return(None)],
                     else_body: Some(vec![Statement::Return(None)]),
@@ -924,7 +921,7 @@ mod tests {
         let expected = Some(Statement::Return(Some(Expr::Binary(Binary {
             left: Box::new(Expr::Identifier("x".to_string())),
             operator: BinaryOperator::Add,
-            right: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "5".to_string() })),
+            right: Box::new(Expr::IntLiteral("5".to_string())),
         }))));
 
         let mut parser = Parser::new(&tokens);
@@ -945,7 +942,7 @@ mod tests {
             value: Box::new(Expr::Binary(Binary {
                 left: Box::new(Expr::Identifier("x".to_string())),
                 operator: BinaryOperator::Add,
-                right: Box::new(Expr::IntLiteral(IntLiteral { negative: false, value: "5".to_string() })),
+                right: Box::new(Expr::IntLiteral("5".to_string())),
             })),
         }));
 
@@ -991,40 +988,25 @@ mod tests {
                                 left: Box::new(Expr::Binary(Binary { 
                                     left: Box::new(Expr::Identifier("a".to_string())), 
                                     operator: BinaryOperator::Add, 
-                                    right: Box::new(Expr::IntLiteral(IntLiteral { 
-                                        negative: false, 
-                                        value: "3".to_string() 
-                                    })) 
+                                    right: Box::new(Expr::IntLiteral("3".to_string())) 
                                 })), 
                                 operator: BinaryOperator::Divide, 
-                                right: Box::new(Expr::IntLiteral(IntLiteral { 
-                                    negative: false, 
-                                    value: "4".to_string() 
-                                })) 
+                                right: Box::new(Expr::IntLiteral("4".to_string())) 
                             })), 
                             operator: BinaryOperator::Multiply, 
-                            right: Box::new(Expr::IntLiteral(IntLiteral { 
-                                negative: false, 
-                                value: "5".to_string() 
-                            })) 
+                            right: Box::new(Expr::IntLiteral("5".to_string())) 
                         })), 
                         operator: BinaryOperator::Remainder, 
-                        right: Box::new(Expr::IntLiteral(IntLiteral { 
-                            negative: false, 
-                            value: "3".to_string() 
-                        })) 
+                        right: Box::new(Expr::IntLiteral("3".to_string())) 
                     })), 
                     operator: BinaryOperator::Multiply, 
-                    right: Box::new(Expr::IntLiteral(IntLiteral { 
-                        negative: true, 
-                        value: "2".to_string() 
+                    right: Box::new(Expr::Unary(Unary {
+                        operator: UnaryOperator::Negate, 
+                        operand: Box::new(Expr::IntLiteral("2".to_string()))
                     }))
                 })), 
                 operator: BinaryOperator::Subtract, 
-                right: Box::new(Expr::IntLiteral(IntLiteral { 
-                    negative: false, 
-                    value: "2".to_string() 
-                }))
+                right: Box::new(Expr::IntLiteral("2".to_string()))
             }))
         }));
 
@@ -1050,10 +1032,7 @@ mod tests {
             operator: UnaryOperator::Cast(Type::Int(IntType { width: 64, signed: true })),
             operand: Box::new(Expr::Call(Call {
                 function_name: "foo".to_string(),
-                args: vec![Expr::IntLiteral(IntLiteral {
-                    negative: false,
-                    value: "1".to_string(),
-                })],
+                args: vec![Expr::IntLiteral("1".to_string())],
             })),
         });
 

--- a/src/typing/typed_ast.rs
+++ b/src/typing/typed_ast.rs
@@ -109,7 +109,6 @@ pub struct TypedBinary {
 /// A typed version of [IntLiteral](crate::ast::Expr::IntLiteral)
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypedIntLiteral {
-    pub negative: bool,
     pub int_value: String,
     pub int_type: IntType,
 }

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -484,7 +484,9 @@ impl Typer {
         }
     }
 
-    /// Panics if the cast is invalid, like casting from an unsigned type to a signed type.
+    /// Panics if the operand type cannot be negated
+    ///
+    /// For example, unsigned integers cannot be negated
     fn check_valid_negation(operand_type: &Type) {
         match operand_type {
             Type::Int(IntType { signed: true, .. }) => (),

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -273,7 +273,7 @@ impl Typer {
                 )
             }
 
-            (UnaryOperator::Negate, None) => None,
+            (UnaryOperator::Negate, None) => Some(&Type::Int(IntType { signed: true, width: 64 })),
             (UnaryOperator::Negate, Some(t @ Type::Int(IntType { signed: false, .. }))) => {
                panic!("Expected an unsigned expression of type '{}', but found a negation", t)
             },

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -1,6 +1,6 @@
 use crate::ast::{
     Assignment, Binary, Call, Comparison, Expr, FuncDef, FuncProto, FuncVisibility,
-    GlobalStatement, If, IntLiteral, Program, Statement, Unary, UnaryOperator, VarDeclaration,
+    GlobalStatement, If, Program, Statement, Unary, UnaryOperator, VarDeclaration,
     WhileLoop,
 };
 use crate::scope_manager::ScopeManager;
@@ -273,11 +273,12 @@ impl Typer {
                 )
             }
 
-            // (UnaryOperator::Negate(_), Some(t @ Type::Int(IntType { signed: false, .. }))) => {
-            //    panic!("Expected an unsigned expression of type '{}', but found a negation", t)
-            // },
-            // (UnaryOperator::Negate(_), Some(t @ Type::Int(_))) => t,
-            // (UnaryOperator::Negate(_), Some(t )) => panic!("Cannot negate a non-integer type '{}'", t),
+            (UnaryOperator::Negate, None) => None,
+            (UnaryOperator::Negate, Some(t @ Type::Int(IntType { signed: false, .. }))) => {
+               panic!("Expected an unsigned expression of type '{}', but found a negation", t)
+            },
+            (UnaryOperator::Negate, Some(t @ Type::Int(_))) => Some(t),
+            (UnaryOperator::Negate, Some(t )) => panic!("Cannot negate a non-integer type '{}'", t),
         };
 
         let typed_operand = self.type_expr(&unary.operand, desired_operand_type);
@@ -286,11 +287,12 @@ impl Typer {
         // Now that we know the type of the operand, we can check if the unary operator is valid
         match &unary.operator {
             UnaryOperator::Cast(cast_type) => Self::check_valid_cast(&cast_type, &operand_type),
+            UnaryOperator::Negate => Self::check_valid_negation(&operand_type)
         }
 
         let result_type = match &unary.operator {
             UnaryOperator::Cast(cast_type) => cast_type.clone(),
-            // UnaryOperator::Negate(_) => operand_type,
+            UnaryOperator::Negate => operand_type,
         };
 
         TypedUnary {
@@ -326,7 +328,7 @@ impl Typer {
 
     /// Checks that `desired_type` is a valid type (namely, an integer type) and wraps the
     /// `int_literal` as a `TypedIntLiteral`.
-    fn type_int_literal(&self, int_literal: &IntLiteral, desired_type: Option<&Type>) -> TypedIntLiteral {
+    fn type_int_literal(&self, int_literal: &str, desired_type: Option<&Type>) -> TypedIntLiteral {
         let int_type = match desired_type {
             Some(Type::Int(int_type)) => *int_type,
             Some(t) => {
@@ -338,15 +340,10 @@ impl Typer {
             None => IntType { signed: false, width: 64 },
         };
 
-        if int_literal.negative && !int_type.signed {
-            panic!("Expected unsigned integer type '{}', but got negative int_literal '{}'", int_type, int_literal);
-        }
-
         // TODO: Ensure that the int_literal.value fits within the desired width
 
         TypedIntLiteral {
-            negative: int_literal.negative,
-            int_value: int_literal.value.clone(),
+            int_value: int_literal.to_string(),
             int_type,
         }
     }
@@ -486,6 +483,15 @@ impl Typer {
             ),
         }
     }
+
+    /// Panics if the cast is invalid, like casting from an unsigned type to a signed type.
+    fn check_valid_negation(operand_type: &Type) {
+        match operand_type {
+            Type::Int(IntType { signed: true, .. }) => (),
+            Type::Int(IntType { signed: false, .. }) => panic!("Cannot negate an unsigned type: '{}'", operand_type),
+            t => panic!("Cannot negate a non-integer type '{}'", t)
+        }
+    }
 }
 
 /// As suggested by Clippy's [new_without_default][a], since [Typer::new()] doesn't
@@ -594,7 +600,7 @@ mod tests {
                 body: vec![
                     Statement::VarDeclaration(VarDeclaration {
                         var_name: "a".to_string(),
-                        var_value: Expr::IntLiteral(IntLiteral { negative: false, value: "3".to_string() }),
+                        var_value: Expr::IntLiteral("3".to_string()),
                         var_type: Type::Int(IntType { signed: true, width: 64 }),
                     }),
                     Statement::VarDeclaration(VarDeclaration {
@@ -634,7 +640,7 @@ mod tests {
                 body: vec![
                     Statement::VarDeclaration(VarDeclaration {
                         var_name: "a".to_string(),
-                        var_value: Expr::IntLiteral(IntLiteral { negative: false, value: "3".to_string() }),
+                        var_value: Expr::IntLiteral("3".to_string()),
                         var_type: Type::Int(IntType { width: 8, signed: false }),
                     }),
                     Statement::VarDeclaration(VarDeclaration {
@@ -659,7 +665,6 @@ mod tests {
                     TypedStatement::VarDeclaration(TypedVarDeclaration {
                         var_name: "a".to_string(),
                         var_value: TypedExpr::IntLiteral(TypedIntLiteral {
-                            negative: false,
                             int_value: "3".to_string(),
                             int_type: IntType { width: 8, signed: false },
                         }),
@@ -705,10 +710,7 @@ mod tests {
                 body: vec![
                     Statement::VarDeclaration(VarDeclaration {
                         var_name: "a".to_string(),
-                        var_value: Expr::IntLiteral(IntLiteral {
-                            negative: false,
-                            value: "3".to_string(),
-                        }),
+                        var_value: Expr::IntLiteral("3".to_string()),
                         var_type: Type::Int(IntType { width: 32, signed: true }),
                     }),
                     Statement::Return(Some(Expr::Unary(Unary {
@@ -741,10 +743,7 @@ mod tests {
                 body: vec![
                     Statement::VarDeclaration(VarDeclaration {
                         var_name: "a".to_string(),
-                        var_value: Expr::IntLiteral(IntLiteral {
-                            negative: false,
-                            value: "3".to_string(),
-                        }),
+                        var_value: Expr::IntLiteral("3".to_string()),
                         var_type: Type::Int(IntType { width: 32, signed: false }),
                     }),
                     Statement::Return(Some(Expr::Unary(Unary {
@@ -767,7 +766,6 @@ mod tests {
                     TypedStatement::VarDeclaration(TypedVarDeclaration {
                         var_name: "a".to_string(),
                         var_value: TypedExpr::IntLiteral(TypedIntLiteral {
-                            negative: false,
                             int_value: "3".to_string(),
                             int_type: IntType { width: 32, signed: false },
                         }),


### PR DESCRIPTION
Switch from negative being specific to int literals to making it a unary operator. This allows `-a` to be parsed (and compiled correctly). 

In the future, we need to implement auto typing, so the type of int literals is not fixed but instead dynamically assigned based on surrounding context.