### PR TITLE
Ensure control path always returns

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -23,6 +23,7 @@
 ## Roadmap to a better langauge
 
 - [ ] _Auto_ casting int types / escalating them
+- [ ] Add ".always_true()" to TypedExpr and use that inside of "always_returns()" to analyze loops and ifs
 - [ ] Think deeper about how we want to handle u8 and i8 common type
 - [ ] Fully nice error message (maybe look into anyhow or thiserror?)
 - [ ] Implement importing of other files

--- a/grammar.txt
+++ b/grammar.txt
@@ -30,7 +30,7 @@ unary_expr       := unary_op unary_expr | primary_expr
 primary_expr     := atom | call | '(' expr ')'
                            ^^^^ will become call_and_index_expr
 
-unary_op     :=  '(' VARTYPE ')'   # In the future, we will add | '-' | '!', etc.
+unary_op     :=  '(' VARTYPE ')' | '-'
 
 // call_and_index_expr  := IDENTIFIER { [ '(' [args] ')' ] { '[' [index]  ']' } }
 call        := IDENTIFIER [ '(' [args] ')' ]

--- a/src/compilation/compiler.rs
+++ b/src/compilation/compiler.rs
@@ -293,6 +293,7 @@ impl Compiler {
             TypedStatement::Return(r) => self.compile_ret_statement(r),
             TypedStatement::Call(c) => _ = self.compile_call(c),
             TypedStatement::If(i) => self.compile_if_statement(i),
+            TypedStatement::Unreachable => { LLVMBuildUnreachable(self.builder); },
         }
     }
 

--- a/src/compilation/compiler.rs
+++ b/src/compilation/compiler.rs
@@ -293,7 +293,7 @@ impl Compiler {
             TypedStatement::Return(r) => self.compile_ret_statement(r),
             TypedStatement::Call(c) => _ = self.compile_call(c),
             TypedStatement::If(i) => self.compile_if_statement(i),
-            TypedStatement::Unreachable => { LLVMBuildUnreachable(self.builder); },
+            TypedStatement::Unreachable => self.compile_unreachable(),
         }
     }
 
@@ -671,6 +671,11 @@ impl Compiler {
             return None;
         }
         Some(cur_func)
+    }
+    
+    /// Compiles an unreachable instruction, terminating the current block.
+    unsafe fn compile_unreachable(&self) {
+        LLVMBuildUnreachable(self.builder);
     }
 }
 

--- a/src/typing/typed_ast.rs
+++ b/src/typing/typed_ast.rs
@@ -56,16 +56,13 @@ impl TypedStatement {
 
             Self::WhileLoop(while_loop) => some_statement_always_returns(&while_loop.body),
 
-            Self::If(if_stmt) => {
-                let then_always_returns = some_statement_always_returns(&if_stmt.then_body);
-                let else_always_returns = match if_stmt.else_body.as_ref() {
-                    Some(else_body) => some_statement_always_returns(else_body),
-                    None => true,
-                };
-        
-                then_always_returns && else_always_returns
-            }
-
+            // Without an 'else' branch, an if statement doesn't always return
+            Self::If(TypedIf { else_body: None, .. }) => false,
+            // With an 'else' branch, it always returns if both branches always return
+            Self::If(TypedIf { else_body: Some(else_body), then_body, .. }) => {
+                some_statement_always_returns(else_body)
+                && some_statement_always_returns(&then_body)
+            },
         }
     }
 }

--- a/src/typing/typed_ast.rs
+++ b/src/typing/typed_ast.rs
@@ -38,6 +38,12 @@ pub enum TypedStatement {
     Return(Option<TypedExpr>),
     Call(TypedCall),
     If(TypedIf),
+
+    /// Compiles to LLVM's UnreachableInst
+    /// 
+    /// The type checker places this at the end of functions that don't expliclty return on their final line,
+    /// but whose control flow analysis shows that they always return prior to the final line.
+    Unreachable,
 }
 
 
@@ -63,6 +69,8 @@ impl TypedStatement {
                 some_statement_always_returns(else_body)
                 && some_statement_always_returns(&then_body)
             },
+
+            Self::Unreachable => panic!("Unreachable statements should not be analyzed for always_returns"),
         }
     }
 }

--- a/src/typing/typed_ast.rs
+++ b/src/typing/typed_ast.rs
@@ -60,7 +60,8 @@ impl TypedStatement {
             Self::VarDeclaration(_) | Self::Assignment(_) | Self::Call(_) => false,
             Self::Return(_) => true,
 
-            Self::WhileLoop(while_loop) => some_statement_always_returns(&while_loop.body),
+            // While loops can't always return; their condition might be false
+            Self::WhileLoop(_) => false,
 
             // Without an 'else' branch, an if statement doesn't always return
             Self::If(TypedIf { else_body: None, .. }) => false,

--- a/src/typing/typed_ast.rs
+++ b/src/typing/typed_ast.rs
@@ -40,6 +40,36 @@ pub enum TypedStatement {
     If(TypedIf),
 }
 
+
+/// Returns true if any of the statements in the slice always return.
+pub fn some_statement_always_returns(statements: &[TypedStatement]) -> bool {
+    statements.iter().any(|stmt| stmt.always_returns())
+}
+
+
+impl TypedStatement {
+    /// Returns true if this statement always returns, no matter the control flow.
+    pub fn always_returns(&self) -> bool {
+        match self {
+            Self::VarDeclaration(_) | Self::Assignment(_) | Self::Call(_) => false,
+            Self::Return(_) => true,
+
+            Self::WhileLoop(while_loop) => some_statement_always_returns(&while_loop.body),
+
+            Self::If(if_stmt) => {
+                let then_always_returns = some_statement_always_returns(&if_stmt.then_body);
+                let else_always_returns = match if_stmt.else_body.as_ref() {
+                    Some(else_body) => some_statement_always_returns(else_body),
+                    None => true,
+                };
+        
+                then_always_returns && else_always_returns
+            }
+
+        }
+    }
+}
+
 /// A typed version of [VarDeclaration](crate::ast::VarDeclaration)
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct TypedVarDeclaration {

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -122,6 +122,11 @@ impl Typer {
             if !some_statement_always_returns(&func_body) {
                 panic!("Function '{}' does not always return a value", func_def.proto.name);
             }
+
+            match func_body.last() {
+                Some(TypedStatement::Return(_)) => {}
+                _ => func_body.push(TypedStatement::Unreachable),
+            }
         }
 
         self.scope_manager.exit_scope();

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -111,17 +111,17 @@ impl Typer {
 
         let mut func_body = self.type_body(&func_def.body, &func_def.proto.return_type);
 
-        // Implicitly return void at end of functions with void return type
         if Type::Void == *func_def.proto.return_type {
+            // Void functions: implicitly return to make sure the basic block is terminated
             match func_body.last() {
                 Some(TypedStatement::Return(_)) => {}
                 _ => func_body.push(TypedStatement::Return(None)),
             }
-        } 
-        
-        // Confirm that non-void functions always return a value
-        if Type::Void != *func_def.proto.return_type && !some_statement_always_returns(&func_body) {
-            panic!("Function '{}' does not always return a value", func_def.proto.name);
+        } else {
+            // Non-void functions: make sure all control paths lead to a return
+            if !some_statement_always_returns(&func_body) {
+                panic!("Function '{}' does not always return a value", func_def.proto.name);
+            }
         }
 
         self.scope_manager.exit_scope();

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -123,10 +123,9 @@ impl Typer {
                 panic!("Function '{}' does not always return a value", func_def.proto.name);
             }
 
-            match func_body.last() {
-                Some(TypedStatement::Return(_)) => {}
-                _ => func_body.push(TypedStatement::Unreachable),
-            }
+           if !func_body.last().is_some_and(|s| s.always_returns()) {
+                func_body.push(TypedStatement::Unreachable)
+           }
         }
 
         self.scope_manager.exit_scope();

--- a/src/typing/typer.rs
+++ b/src/typing/typer.rs
@@ -235,7 +235,14 @@ impl Typer {
         ret: Option<&Expr>,
         function_return_type: &Type,
     ) -> Option<TypedExpr> {
-        ret.map(|e| self.type_expr(e, Some(function_return_type)))
+        match (ret, function_return_type) {
+            (Some(_), Type::Void) => panic!("Expected function to return nothing, but found 'ret' with a value"),
+            (Some(expr), desired) => Some(self.type_expr(expr, Some(desired))),
+            (None, Type::Void) => None,
+            (None, _) => panic!(
+                "Expected function to return a '{}', but found 'ret' without a value", function_return_type
+            )
+        }
     }
 
     /// Recursively type-checks the provided expression, confirming that it is of type


### PR DESCRIPTION
Previously, the following could would not be caught during type-checking:

```
fn foo() u8 {
}
```

```
fn foo() u8 {
  ret
}
```

This is now fixed. Essentially, I added a function to determine whether a given statement always returns (or whether it might allow control to keep flowing). So, this is also allowed, even though there's no "ret" at the end:

```
fn min(u8 a, u8 b) u8 {
    if a < b  {
        ret a
    } else {
        ret b
    }
}
```